### PR TITLE
kernel: fix ksu_sys_umount compatibility

### DIFF
--- a/kernel/core_hook.c
+++ b/kernel/core_hook.c
@@ -570,7 +570,11 @@ static void ksu_sys_umount(const char *mnt, int flags)
 
 	mm_segment_t old_fs = get_fs();
 	set_fs(KERNEL_DS);
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 17, 0)
+	int ret = ksys_umount(usermnt, flags);
+#else
 	long ret = sys_umount(usermnt, flags); // cuz asmlinkage long sys##name
+#endif
 	set_fs(old_fs);
 	pr_info("%s: path: %s code: %d \n", __func__, usermnt, ret);
 }


### PR DESCRIPTION
* Some people reports about undefined reference to `sys_umount`
* Since ksys_umount exist on Linux 4.17-rc1, then we gonna use that one.

Rev 2: Use correct int instead of long for ksys_umount