### PR TITLE
manager: ksuEngine as default WebUI engine

### DIFF
--- a/manager/app/src/main/java/com/sukisu/ultra/ui/screen/Module.kt
+++ b/manager/app/src/main/java/com/sukisu/ultra/ui/screen/Module.kt
@@ -391,7 +391,7 @@ fun ModuleScreen(navigator: DestinationsNavigator) {
                                     when (config.getWebuiEngine(context)) {
                                         "wx" -> wxEngine
                                         "ksu" -> ksuEngine
-                                        else -> wxEngine
+                                        else -> ksuEngine
                                     }
                                 )
                                 return@ModuleList


### PR DESCRIPTION
## Explain commit 
Last [commit](https://github.com/SukiSU-Ultra/SukiSU-Ultra/commit/439b99cc4a3e126e5dbf10cc12b60168212712d3) add a feature to allow module  to use which WebUI engine. But this ignores a problem that not all modules' webui is design for WebUIX. 
Also, last commit also break the option of using WebUIX or not.