### PR TITLE
Rewrite kernle version code management

### DIFF
--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -23,28 +23,20 @@ REPO_OWNER := SukiSU-Ultra
 REPO_NAME := SukiSU-Ultra
 REPO_BRANCH := main
 
+KSU_RELEASE_ID := zako
+KSU_API_VERSION := 1
+
 GIT_BIN := /usr/bin/env PATH="$$PATH":/usr/bin:/usr/local/bin git
 CURL_BIN := /usr/bin/env PATH="$$PATH":/usr/bin:/usr/local/bin curl
 
-KSU_GITHUB_VERSION := $(shell $(CURL_BIN) -sI "https://api.github.com/repos/$(REPO_OWNER)/$(REPO_NAME)/commits?sha=$(REPO_BRANCH)&per_page=1" | grep -i "link:" | sed -n 's/.*page=\([0-9]*\)>; rel="last".*/\1/p')
+KSU_BRANCH_NAME := $(shell $(GIT_BIN) rev-parse --abbrev-ref HEAD)
+KSU_COMMIT_HASH := $(shell $(GIT_BIN) rev-parse --short=8 HEAD)
 
-ifeq ($(KSU_GITHUB_VERSION),)
-  ifeq ($(shell test -e $(srctree)/$(src)/../.git; echo $$?),0)
-    $(shell cd $(srctree)/$(src); [ -f ../.git/shallow ] && $(GIT_BIN) fetch --unshallow)
-    KSU_LOCAL_VERSION := $(shell cd $(srctree)/$(src); $(GIT_BIN) rev-list --count HEAD)
-    $(eval KSU_VERSION := $(shell expr 10000 + $(KSU_LOCAL_VERSION) + 700))
-    $(info -- SukiSU-Ultra version (local .git): $(KSU_VERSION))
-  else
-    $(eval KSU_VERSION := 13000)
-    $(warning -- Could not fetch version online or via local .git! Using fallback version: $(KSU_VERSION))
-  endif
-else
-  $(eval KSU_VERSION := $(shell expr 10000 + $(KSU_GITHUB_VERSION) + 700))
-  $(info -- SukiSU-Ultra version (GitHub): $(KSU_VERSION))
-endif
+KSU_VERSION := "v$(KSU_API_VERSION)-$(KSU_RELEASE_ID)-$(KSU_COMMIT_HASH)$(KSU_BRANCH_NAME)"
 
 $(info -- SukiSU-Ultra version: $(KSU_VERSION))
 ccflags-y += -DKSU_VERSION=$(KSU_VERSION)
+ccflags-y += -DKSU_API_VERSION=$(KSU_API_VERSION)
 
 ifndef KSU_EXPECTED_SIZE
 KSU_EXPECTED_SIZE := 0x35c

--- a/kernel/core_hook.c
+++ b/kernel/core_hook.c
@@ -308,7 +308,7 @@ int ksu_handle_prctl(int option, unsigned long arg2, unsigned long arg3,
 		if (copy_to_user(arg3, &version, sizeof(version))) {
 			pr_err("prctl reply error, cmd: %lu\n", arg2);
 		}
-		u32 version_flags = 0;
+		u32 version_flags = 2;
 #ifdef MODULE
 		version_flags |= 0x1;
 #endif
@@ -415,6 +415,14 @@ int ksu_handle_prctl(int option, unsigned long arg2, unsigned long arg3,
 		} else {
 			pr_err("prctl copy err, cmd: %lu\n", arg2);
 		}
+		return 0;
+	}
+
+	if (arg2 == CMD_GET_FULL_VERSION) {
+		if (copy_to_user(arg3, &ksu_version_id, KSU_MAX_VERSION_NAME)) {
+			pr_err("prctl reply error, cmd: %lu\n", arg2);
+		}
+
 		return 0;
 	}
 

--- a/kernel/ksu.h
+++ b/kernel/ksu.h
@@ -4,7 +4,7 @@
 #include <linux/types.h>
 #include <linux/workqueue.h>
 
-#define KERNEL_SU_VERSION KSU_VERSION
+#define KERNEL_SU_VERSION KSU_API_VERSION
 #define KERNEL_SU_OPTION 0xDEADBEEF
 
 #define CMD_GRANT_ROOT 0
@@ -23,6 +23,7 @@
 #define CMD_UID_SHOULD_UMOUNT 13
 #define CMD_IS_SU_ENABLED 14
 #define CMD_ENABLE_SU 15
+#define CMD_GET_FULL_VERSION 16
 #define CMD_ENABLE_KPM 100
 
 #define EVENT_POST_FS_DATA 1
@@ -34,6 +35,13 @@
 // NGROUPS_MAX for Linux is 65535 generally, but we only supports 32 groups.
 #define KSU_MAX_GROUPS 32
 #define KSU_SELINUX_DOMAIN 64
+
+#define KSU_MAX_VERSION_NAME 255
+
+#ifndef KSU_VERSION 
+#define KSU_VERSION "v0-unknown-00000000@unkown"
+#endif
+char ksu_version_id[KSU_MAX_VERSION_NAME] = KSU_VERSION;
 
 struct root_profile {
 	int32_t uid;

--- a/manager/app/src/main/cpp/jni.c
+++ b/manager/app/src/main/cpp/jni.c
@@ -19,6 +19,12 @@ NativeBridgeNP(getVersion, jint) {
     return get_version();
 }
 
+NativeBridgeNP(getFullVersion, jstring) {
+    char buff[255] = { 0 };
+    get_full_version(&buff);
+    return GetEnvironment()->NewStringUTF(env, buff);
+}
+
 NativeBridgeNP(getAllowList, jintArray) {
     int uids[1024];
     int size = 0;

--- a/manager/app/src/main/cpp/ksu.c
+++ b/manager/app/src/main/cpp/ksu.c
@@ -30,6 +30,8 @@
 #define CMD_IS_UID_SHOULD_UMOUNT 13
 #define CMD_IS_SU_ENABLED 14
 #define CMD_ENABLE_SU 15
+#define CMD_GET_VERSION_FULL 16
+
 #define CMD_ENABLE_KPM 100
 #define CMD_HOOK_TYPE 101
 #define CMD_GET_SUSFS_FEATURE_STATUS 102
@@ -60,10 +62,14 @@ int get_version() {
     int32_t version = -1;
     int32_t lkm = 0;
     ksuctl(CMD_GET_VERSION, &version, &lkm);
-    if (!is_lkm && lkm != 0) {
+    if (!is_lkm && lkm == 1) {
         is_lkm = true;
     }
     return version;
+}
+
+void get_full_version(char* buff) {
+    ksuctl(CMD_GET_VERSION_FULL, buff, NULL);
 }
 
 bool get_allow_list(int *uids, int *size) {

--- a/manager/app/src/main/cpp/ksu.h
+++ b/manager/app/src/main/cpp/ksu.h
@@ -12,6 +12,8 @@ bool become_manager(const char *);
 
 int get_version();
 
+void get_full_version(char* buff);
+
 bool get_allow_list(int *uids, int *size);
 
 bool uid_should_umount(int uid);

--- a/manager/app/src/main/java/com/sukisu/ultra/Natives.kt
+++ b/manager/app/src/main/java/com/sukisu/ultra/Natives.kt
@@ -50,6 +50,8 @@ object Natives {
     val isLkmMode: Boolean
         external get
 
+    external fun getFullVersion(): String
+
     external fun uidShouldUmount(uid: Int): Boolean
 
     /**

--- a/manager/app/src/main/java/com/sukisu/ultra/ui/screen/Home.kt
+++ b/manager/app/src/main/java/com/sukisu/ultra/ui/screen/Home.kt
@@ -439,7 +439,7 @@ private fun StatusCard(
                         if (!isHideVersion) {
                             Spacer(Modifier.height(4.dp))
                             Text(
-                                text = stringResource(R.string.home_working_version, systemStatus.ksuVersion),
+                                text = stringResource(R.string.home_working_version, Natives.getFullVersion()),
                                 style = MaterialTheme.typography.bodyMedium,
                                 color = MaterialTheme.colorScheme.secondary,
                             )
@@ -725,7 +725,7 @@ private fun InfoCard(
 
             if (!isSimpleMode) {
                 // 根据showKpmInfo决定是否显示KPM信息
-                if (lkmMode != true && !showKpmInfo && Natives.version >= Natives.MINIMAL_SUPPORTED_KPM) {
+                if (lkmMode != true && !showKpmInfo) {
                     val displayVersion = if (systemInfo.kpmVersion.isEmpty() || systemInfo.kpmVersion.startsWith("Error")) {
                         val statusText = if (Natives.isKPMEnabled()) {
                             stringResource(R.string.kernel_patched)

--- a/manager/app/src/main/res/values/strings.xml
+++ b/manager/app/src/main/res/values/strings.xml
@@ -5,7 +5,7 @@
     <string name="home_not_installed">Not installed</string>
     <string name="home_click_to_install">Click to install</string>
     <string name="home_working">Working</string>
-    <string name="home_working_version">Version: %d</string>
+    <string name="home_working_version">Version: %s</string>
     <string name="home_unsupported">Unsupported</string>
     <string name="home_unsupported_reason">No KernelSU driver detected on your kernel, wrong kernel?.</string>
     <string name="home_kernel">Kernel version</string>


### PR DESCRIPTION
完全重写内核版本号管理机制，内核部分不再数 commit 计算版本号，而是通过在 Makefile 中手动设置版本号。

版本号的格式为 `<API版本>-<版本字符串，建议命名为ksu实现名>-<提交哈希>@<分支>`。
例如：`v1-zako-aabbccdd@master`，他的含义是，prctl API 版本为 1，ksu实现是 zakosu，提交是 master分支上的aabbccdd。

其中 API版本 需要手动增加，当 core_hook.c 中 prctl API 有变动时（例如增加了新的 API，或者现有 API参数有变化等）才增加版本号，若内核更新了新的功能，但 prctl 无变化，则不增加该版本号。这样设计的意义是让 manager 和 内核部分独立开来，只要 API 兼容，则无论内核 / manager怎么修改都不影响兼容性，也就无需为内核更新 manager 或者为 manager 更新内核。

***代码没测试***

