### PR TITLE
Kernel: use main branch commit count for consistent versioning

### DIFF
--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -31,7 +31,7 @@ KSU_GITHUB_VERSION := $(shell $(CURL_BIN) -sI "https://api.github.com/repos/$(RE
 ifeq ($(KSU_GITHUB_VERSION),)
   ifeq ($(shell test -e $(srctree)/$(src)/../.git; echo $$?),0)
     $(shell cd $(srctree)/$(src); [ -f ../.git/shallow ] && $(GIT_BIN) fetch --unshallow)
-    KSU_LOCAL_VERSION := $(shell cd $(srctree)/$(src); $(GIT_BIN) rev-list --count HEAD)
+    KSU_LOCAL_VERSION := $(shell cd $(srctree)/$(src); $(GIT_BIN) rev-list --count $(REPO_BRANCH))
     $(eval KSU_VERSION := $(shell expr 10000 + $(KSU_LOCAL_VERSION) + 700))
     $(info -- SukiSU-Ultra version (local .git): $(KSU_VERSION))
   else


### PR DESCRIPTION
原先版本号是通过当前分支的提交次数计算得出，当 GitHub API 获取失败时，会回退使用当前分支的本地提交数。
这可能导致 `susfs` 分支的版本号低于管理器要求的版本号，从而引发功能异常。

此次修复统一使用 `main` 分支的提交次数作为版本基础，无论是通过 GitHub API 还是本地 .git 仓库，均保持一致，确保版本号的一致性。

同 Github API 使用 `REPO_BRANCH` 变量方便后期的修改和维护