### PR TITLE
Refactored the versioning logic

### DIFF
--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -22,7 +22,7 @@ obj-$(CONFIG_KPM) += kpm/
 REPO_OWNER := SukiSU-Ultra
 REPO_NAME := SukiSU-Ultra
 REPO_BRANCH := main
-KSU_API_VERSION_LOCAL := 3.1.6
+KSU_VERSION_API := 3.1.6
 
 GIT_BIN := /usr/bin/env PATH="$$PATH":/usr/bin:/usr/local/bin git
 CURL_BIN := /usr/bin/env PATH="$$PATH":/usr/bin:/usr/local/bin curl
@@ -32,7 +32,7 @@ KSU_GITHUB_VERSION_COMMIT := $(shell $(CURL_BIN) -sI "https://api.github.com/rep
 
 LOCAL_GIT_EXISTS := $(shell test -e $(srctree)/$(src)/../.git && echo 1 || echo 0)
 
-define get_ksu_kernel_version
+define get_ksu_version_full
 v$1-$(shell cd $(srctree)/$(src); $(GIT_BIN) rev-parse --short=8 HEAD)@$(shell cd $(srctree)/$(src); $(GIT_BIN) rev-parse --abbrev-ref HEAD)
 endef
 
@@ -40,35 +40,35 @@ ifeq ($(KSU_GITHUB_VERSION_COMMIT),)
   ifeq ($(LOCAL_GIT_EXISTS),1)
     $(shell cd $(srctree)/$(src); [ -f ../.git/shallow ] && $(GIT_BIN) fetch --unshallow)
     KSU_LOCAL_VERSION := $(shell cd $(srctree)/$(src); $(GIT_BIN) rev-list --count $(REPO_BRANCH))
-    KSU_API_VERSION := $(shell expr 10000 + $(KSU_LOCAL_VERSION) + 700)
-    $(info -- $(REPO_NAME) version (local .git): $(KSU_API_VERSION))
+    KSU_VERSION := $(shell expr 10000 + $(KSU_LOCAL_VERSION) + 700)
+    $(info -- $(REPO_NAME) version (local .git): $(KSU_VERSION))
   else
-    KSU_API_VERSION := 13000
-    $(warning -- Could not fetch version online or via local .git! Using fallback version: $(KSU_API_VERSION))
+    KSU_VERSION := 13000
+    $(warning -- Could not fetch version online or via local .git! Using fallback version: $(KSU_VERSION))
   endif
 else
-  KSU_API_VERSION := $(shell expr 10000 + $(KSU_GITHUB_VERSION_COMMIT) + 700)
-  $(info -- $(REPO_NAME) version (GitHub): $(KSU_API_VERSION))
+  KSU_VERSION := $(shell expr 10000 + $(KSU_GITHUB_VERSION_COMMIT) + 700)
+  $(info -- $(REPO_NAME) version (GitHub): $(KSU_VERSION))
 endif
 
 ifeq ($(KSU_GITHUB_VERSION),)
   ifeq ($(LOCAL_GIT_EXISTS),1)
     $(shell cd $(srctree)/$(src); [ -f ../.git/shallow ] && $(GIT_BIN) fetch --unshallow)
-    KSU_KERNEL_VERSION := $(call get_ksu_kernel_version,$(KSU_API_VERSION_LOCAL))
-    $(info -- $(REPO_NAME) version (local .git): $(KSU_KERNEL_VERSION))
-    $(info -- $(REPO_NAME) Formatted version (local .git): $(KSU_API_VERSION))
+    KSU_VERSION_FULL := $(call get_ksu_version_full,$(KSU_VERSION_API))
+    $(info -- $(REPO_NAME) version (local .git): $(KSU_VERSION_FULL))
+    $(info -- $(REPO_NAME) Formatted version (local .git): $(KSU_VERSION))
   else
-    KSU_KERNEL_VERSION := v$(KSU_API_VERSION_LOCAL)-$(REPO_NAME)-unknown@unknown
-    $(warning -- $(REPO_NAME) version: $(KSU_KERNEL_VERSION))
+    KSU_VERSION_FULL := v$(KSU_VERSION_API)-$(REPO_NAME)-unknown@unknown
+    $(warning -- $(REPO_NAME) version: $(KSU_VERSION_FULL))
   endif
 else
   $(shell cd $(srctree)/$(src); [ -f ../.git/shallow ] && $(GIT_BIN) fetch --unshallow)
-  KSU_KERNEL_VERSION := $(call get_ksu_kernel_version,$(KSU_GITHUB_VERSION))
-  $(info -- $(REPO_NAME) version (Github): $(KSU_KERNEL_VERSION))
+  KSU_VERSION_FULL := $(call get_ksu_version_full,$(KSU_GITHUB_VERSION))
+  $(info -- $(REPO_NAME) version (Github): $(KSU_VERSION_FULL))
 endif
 
-ccflags-y += -DKSU_VERSION=\"$(KSU_KERNEL_VERSION)\"
-ccflags-y += -DKSU_API_VERSION=$(KSU_API_VERSION)
+ccflags-y += -DKSU_VERSION=$(KSU_VERSION)
+ccflags-y += -DKSU_VERSION_FULL=\"$(KSU_VERSION_FULL)\"
 
 ifeq ($(strip $(CONFIG_KSU_MANUAL_HOOK)),y)
 $(info -- SukiSU: Manual hooking enabled!)

--- a/kernel/core_hook.c
+++ b/kernel/core_hook.c
@@ -55,8 +55,6 @@
 #include "kpm/kpm.h"
 #endif
 
-char ksu_version_id[KSU_MAX_VERSION_NAME] = KSU_VERSION;
-
 #ifdef CONFIG_KSU_SUSFS
 bool susfs_is_allow_su(void)
 {
@@ -410,6 +408,21 @@ int ksu_handle_prctl(int option, unsigned long arg2, unsigned long arg3,
 		return 0;
 	}
 
+	// Allow root manager to get full version strings
+	if (arg2 == CMD_GET_FULL_VERSION) {
+		char ksu_version_full[KSU_FULL_VERSION_STRING] = {0};
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 13, 0)
+		strscpy(ksu_version_full, KSU_VERSION_FULL, KSU_FULL_VERSION_STRING);
+#else
+		strlcpy(ksu_version_full, KSU_VERSION_FULL, KSU_FULL_VERSION_STRING);
+#endif
+		if (copy_to_user((void __user *)arg3, ksu_version_full, KSU_FULL_VERSION_STRING)) {
+			pr_err("prctl reply error, cmd: %lu\n", arg2);
+			return -EFAULT;
+		}
+		return 0;
+	}
+
 	if (arg2 == CMD_REPORT_EVENT) {
 		if (!from_root) {
 			return 0;
@@ -509,14 +522,6 @@ int ksu_handle_prctl(int option, unsigned long arg2, unsigned long arg3,
 		} else {
 			pr_err("prctl copy err, cmd: %lu\n", arg2);
 		}
-		return 0;
-	}
-
-	if (arg2 == CMD_GET_FULL_VERSION) {
-		if (copy_to_user(arg3, &ksu_version_id, KSU_MAX_VERSION_NAME)) {
-			pr_err("prctl reply error, cmd: %lu\n", arg2);
-		}
-
 		return 0;
 	}
 

--- a/kernel/ksu.h
+++ b/kernel/ksu.h
@@ -4,7 +4,7 @@
 #include <linux/types.h>
 #include <linux/workqueue.h>
 
-#define KERNEL_SU_VERSION KSU_API_VERSION
+#define KERNEL_SU_VERSION KSU_VERSION
 #define KERNEL_SU_OPTION 0xDEADBEEF
 
 #define CMD_GRANT_ROOT 0
@@ -40,11 +40,11 @@
 #define KSU_MAX_GROUPS 32
 #define KSU_SELINUX_DOMAIN 64
 
-#define KSU_MAX_VERSION_NAME 255
-
-#ifndef KSU_VERSION 
-#define KSU_VERSION "v0-unknown-00000000@unkown"
+// SukiSU Ultra kernel su version full strings
+#ifndef KSU_VERSION_FULL 
+#define KSU_VERSION_FULL "v3.x-00000000@unknown"
 #endif
+#define KSU_FULL_VERSION_STRING 255
 
 // SUSFS Functional State Structures
 struct susfs_feature_status {


### PR DESCRIPTION
Refactored the versioning logic to restore the previous behavior where KSU_VERSION is based on commit count, matching the earlier definition used by CMD_GET_VERSION.

Introduced KSU_VERSION_FULL to provide a human-readable version string.

This should improve compatibility with version display in both old and new root manager apps, though further testing may be needed to catch any edge cases.