### PR TITLE
kernel/core_hook: update version_flags initialization to improve compatibility

### DIFF
--- a/kernel/core_hook.c
+++ b/kernel/core_hook.c
@@ -397,7 +397,7 @@ int ksu_handle_prctl(int option, unsigned long arg2, unsigned long arg3,
 		if (copy_to_user(arg3, &version, sizeof(version))) {
 			pr_err("prctl reply error, cmd: %lu\n", arg2);
 		}
-		u32 version_flags = 2;
+		u32 version_flags = 0;
 #ifdef MODULE
 		version_flags |= 0x1;
 #endif


### PR DESCRIPTION
This commit was previously missed when the upstream branch was updated.
I'm not sure why it was skipped, but it seems to help older root manager apps correctly recognize the LKM or GKI mode, improving compatibility with earlier versions. Although the issue has already been fixed in the latest version, I’m submitting this in case it’s still useful.

If this commit is no longer needed, or if I missed something, feel free to disregard it.