### PR TITLE
manager: Fix unintended LKM dialog when selecting AnyKernel3 install method

### DIFF
--- a/manager/app/src/main/java/com/sukisu/ultra/ui/screen/Install.kt
+++ b/manager/app/src/main/java/com/sukisu/ultra/ui/screen/Install.kt
@@ -186,7 +186,7 @@ fun InstallScreen(navigator: DestinationsNavigator) {
     }
 
     val onClickNext = {
-        if (isGKI && lkmSelection == LkmSelection.KmiNone && currentKmi.isBlank()) {
+        if (isGKI && lkmSelection == LkmSelection.KmiNone && currentKmi.isBlank() && installMethod !is InstallMethod.HorizonKernel) {
             selectKmiDialog.show()
         } else {
             onInstall()


### PR DESCRIPTION
This fixes a logic issue where the KMI selection dialog would still appear
even when the user selected the AnyKernel3 install method.