### PR TITLE
kernel: core_hook: add support for KernelNoSU

### DIFF
--- a/kernel/core_hook.c
+++ b/kernel/core_hook.c
@@ -250,6 +250,16 @@ static void nuke_ext4_sysfs() {
 static inline void nuke_ext4_sysfs() { }
 #endif
 
+static bool is_system_bin_su()
+{
+	// YES in_execve becomes 0 when it succeeds.
+	if (!current->mm || current->in_execve) 
+		return false;
+
+	// quick af check
+	return (current->mm->exe_file && !strcmp(current->mm->exe_file->f_path.dentry->d_name.name, "su"));
+}
+
 int ksu_handle_prctl(int option, unsigned long arg2, unsigned long arg3,
 		     unsigned long arg4, unsigned long arg5)
 {
@@ -272,7 +282,8 @@ int ksu_handle_prctl(int option, unsigned long arg2, unsigned long arg3,
 	bool from_root = 0 == current_uid().val;
 	bool from_manager = is_manager();
 
-	if (!from_root && !from_manager) {
+	if (!from_root && !from_manager 
+		&& !(is_allow_su() && is_system_bin_su())) {
 		// only root or manager can access this interface
 		return 0;
 	}
@@ -488,6 +499,30 @@ int ksu_handle_prctl(int option, unsigned long arg2, unsigned long arg3,
 		return 0;
 	}
 
+	if (arg2 == CMD_ENABLE_SU) {
+		bool enabled = (arg3 != 0);
+		if (enabled == ksu_su_compat_enabled) {
+			pr_info("cmd enable su but no need to change.\n");
+			if (copy_to_user(result, &reply_ok, sizeof(reply_ok))) {// return the reply_ok directly
+				pr_err("prctl reply error, cmd: %lu\n", arg2);
+			}
+			return 0;
+		}
+
+		if (enabled) {
+			ksu_sucompat_init();
+		} else {
+			ksu_sucompat_exit();
+		}
+		ksu_su_compat_enabled = enabled;
+
+		if (copy_to_user(result, &reply_ok, sizeof(reply_ok))) {
+			pr_err("prctl reply error, cmd: %lu\n", arg2);
+		}
+
+		return 0;
+	}
+
 	#ifdef CONFIG_KPM
 	// ADD: 添加KPM模块控制
 	if(sukisu_is_kpm_control_code(arg2)) {
@@ -559,30 +594,6 @@ int ksu_handle_prctl(int option, unsigned long arg2, unsigned long arg3,
 		if (copy_to_user(result, &reply_ok, sizeof(reply_ok))) {
 			pr_err("prctl reply error, cmd: %lu\n", arg2);
 		}
-		return 0;
-	}
-
-	if (arg2 == CMD_ENABLE_SU) {
-		bool enabled = (arg3 != 0);
-		if (enabled == ksu_su_compat_enabled) {
-			pr_info("cmd enable su but no need to change.\n");
-			if (copy_to_user(result, &reply_ok, sizeof(reply_ok))) {// return the reply_ok directly
-				pr_err("prctl reply error, cmd: %lu\n", arg2);
-			}
-			return 0;
-		}
-
-		if (enabled) {
-			ksu_sucompat_init();
-		} else {
-			ksu_sucompat_exit();
-		}
-		ksu_su_compat_enabled = enabled;
-
-		if (copy_to_user(result, &reply_ok, sizeof(reply_ok))) {
-			pr_err("prctl reply error, cmd: %lu\n", arg2);
-		}
-
 		return 0;
 	}
 


### PR DESCRIPTION
参考：https://t.me/krenalxx/1802 https://t.me/krenalxx/1805

reorder ksu_handle_prctl checks a bit to allow non-manager to use CMD 15 this allows us to piggyback a small su to KernelSU's permission system after disabling kernel sucompat

from:
- Relax prctl perm check
https://github.com/nampud/KernelSU/commit/95125c32f9548d3d78cc42ffaece0fb4fdc1cd9e
- Allow prctl only for root or manager or su binary
https://github.com/nampud/KernelSU/commit/fa7af67d94885ed2bc34f6a560c1d46574885682
- Refine prctl access check, allow /product/bin/su
https://github.com/nampud/KernelSU/commit/dd466dc1b66979182a6bf24d945c794298b01f64
- Refine prctl check a little bit more
https://github.com/nampud/KernelSU/commit/e7c5b24efa30e5caef2c024b8ce523e7ecfb04a9