### PR TITLE
UPSTREAM: manager: improve predictive back animations

### DIFF
--- a/manager/app/build.gradle.kts
+++ b/manager/app/build.gradle.kts
@@ -106,6 +106,10 @@ android {
     }
 }
 
+ksp {
+    arg("compose-destinations.defaultTransitions", "none")
+}
+
 dependencies {
     implementation(libs.gson)
     implementation(libs.androidx.activity.compose)


### PR DESCRIPTION
This pull request introduces custom screen transition animations to enhance the overall user experience during navigation.

The key change is the implementation of a custom slide/fade effect for navigating from main screens (i.e., screens hosted in the bottom navigation bar) to detail screens. Transitions between the bottom navigation bar tabs themselves retain a simple, clean cross-fade effect to ensure a fast and smooth user interaction.

This PR also addresses the root cause of an issue where custom animations were being overridden by the navigation library's defaults.

During implementation, it was discovered that custom transition animations defined in the `defaultTransitions` parameter of the `DestinationsNavHost` in `MainActivity` were not being applied. Instead, a default fade-in/fade-out animation was always present.

The root cause was traced to the `compose-destinations` KSP (Kotlin Symbol Processing) code generator. By default, the generator creates a `NavGraphSpec` (e.g., `RootNavGraph.kt`) that includes its own `defaultTransitions` property. This property, defined at compile-time within the generated graph object, has a higher precedence than the `defaultTransitions` parameter supplied to the `DestinationsNavHost` composable at runtime.

As a result, our intended custom animations were being ignored and overridden by the generated default.

To resolve this precedence issue permanently, this PR adopts the official configuration method recommended by the `compose-destinations` library.

- The following KSP argument has been added to the `app/build.gradle.kts` file:

```kotlin
ksp {
    arg("compose-destinations.defaultTransitions", "none")
}
```

- This argument instructs the code generator to omit the `defaultTransitions` property from the generated `NavGraphSpec`.

- By removing the higher-priority, generated default, the `defaultTransitions` parameter on `DestinationsNavHost` now functions as the effective default, allowing our custom animation logic to execute as intended.

The new animation logic is conditional and defined within `MainActivity`. It distinguishes between two primary navigation types:

- Main Screen → Detail Screen:

   - Enter: The new detail screen slides in from the right.

   - Exit: The old main screen slides out to the left while fading out.

- Detail Screen → Main Screen (on Pop):

- Pop Enter: The main screen slides back in from the left while fading in.

   - Pop Exit: The detail screen slides out to the right.

- Between Bottom Navigation Tabs:

- A simple cross-fade (`fadeIn`/`fadeOut`) is maintained for these transitions to provide a quick and non-disruptive experience when switching between primary sections of the app.