### PR TITLE
manager: Remove Loading Dialog when enable/disable the module

### DIFF
--- a/manager/app/src/main/java/com/sukisu/ultra/ui/screen/Module.kt
+++ b/manager/app/src/main/java/com/sukisu/ultra/ui/screen/Module.kt
@@ -843,10 +843,8 @@ private fun ModuleList(
                             },
                             onCheckChanged = {
                                 scope.launch {
-                                    val success = loadingDialog.withLoading {
-                                        withContext(Dispatchers.IO) {
-                                            toggleModule(module.dirId, !module.enabled)
-                                        }
+                                    val success = withContext(Dispatchers.IO) {
+                                        toggleModule(module.dirId, !module.enabled)
                                     }
                                     if (success) {
                                         viewModel.fetchModuleList()


### PR DESCRIPTION
Magic Mount is fast enough that there is almost no need to display a loading animation while waiting
for the backend to finish processing.