### PR TITLE
kernel: ksud: provide is_ksu_transition check v2

### DIFF
--- a/kernel/ksud.c
+++ b/kernel/ksud.c
@@ -27,6 +27,10 @@
 #include "kernel_compat.h"
 #include "selinux/selinux.h"
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 14, 0)
+#include "objsec.h" // task_security_struct
+#endif
+
 bool ksu_is_compat __read_mostly = false; // let it here
 
 static const char KERNEL_SU_RC[] =
@@ -616,6 +620,28 @@ int __maybe_unused ksu_handle_compat_execve_ksud(const char __user *filename_use
 }
 #endif /* COMPAT & 64BIT */
 
+#endif
+
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 14, 0)
+bool is_ksu_transition(const struct task_security_struct *old_tsec,
+					   const struct task_security_struct *new_tsec)
+{
+	static u32 ksu_sid;
+	char *secdata;
+	u32 seclen;
+	bool allowed = false;
+
+	if (!ksu_sid)
+		security_secctx_to_secid("u:r:su:s0", strlen("u:r:su:s0"), &ksu_sid);
+
+	if (security_secid_to_secctx(old_tsec->sid, &secdata, &seclen))
+		return false;
+
+	allowed = (!strcmp("u:r:init:s0", secdata) && new_tsec->sid == ksu_sid);
+	security_release_secctx(secdata, seclen);
+
+	return allowed;
+}
 #endif
 
 static void stop_vfs_read_hook()


### PR DESCRIPTION
context: this is known by many as `selinux hook`, `4.9 hook`

add is_ksu_transition check which allows ksud execution under nosuid. it also eases up integration on 3.X kernels that does not have check_nnp_nosuid.

Usage:
    if (is_ksu_transition(old_tsec, new_tsec))
        return 0;

on either check_nnp_nosuid or selinux_bprm_set_creds (after execve sid reset)

reference:
https://github.com/backslashxx/msm8953-kernel/commits/dfe003c9fdfa394a2bffe74668987a19a0d2f546

taken from:
`allow init exec ksud under nosuid`
- LineageOS/android_kernel_oneplus_msm8998@3df9df4
- tiann#166 (comment)