### PR TITLE
manger: Fix translate module signature verification string

### DIFF
--- a/manager/app/src/main/res/values-in/strings.xml
+++ b/manager/app/src/main/res/values-in/strings.xml
@@ -613,7 +613,7 @@
     <string name="module_verified">Tervalidasi</string>
     <string name="module_signature_verified">Tanda tangan modul tervalidasi</string>
     <string name="module_signature_verification">Verifikasi Tanda Tangan</string>
-    <string name="module_signature_verification_summary">Paksa verifikasi tanda tangan saat memasang modul. (Hanya tersedia untuk arm64-v8a)</string>
+    <string name="module_signature_verification_summary">Verifikasi tanda tangan secara paksa saat modul dipasang. (Hanya tersedia untuk arsitektur ARM)</string>
     <string name="module_signature_invalid">Penerbit tidak dikenal</string>
     <string name="module_signature_invalid_message">Modul yang tidak ditandatangani mungkin tidak lengkap. Untuk melindungi perangkat Anda, pemasangan modul ini diblokir.</string>
     <string name="module_signature_verification_failed">Modul yang tidak ditandatangani mungkin tidak lengkap. Apakah Anda ingin mengizinkan modul berikut dari penerbit tidak dikenal untuk dipasang di perangkat ini?</string>

--- a/manager/app/src/main/res/values-ja/strings.xml
+++ b/manager/app/src/main/res/values-ja/strings.xml
@@ -621,7 +621,7 @@
     <string name="module_verified">検証済み</string>
     <string name="module_signature_verified">モジュールの署名が検証されました</string>
     <string name="module_signature_verification">署名の検証</string>
-    <string name="module_signature_verification_summary">モジュールのインストール時に署名の検証を強制します。(arm64-v8a 環境のみ)</string>
+    <string name="module_signature_verification_summary">モジュールのインストール時に署名の検証を強制します。（ARMアーキテクチャのみ）</string>
     <string name="module_signature_invalid">不明な発行元</string>
     <string name="module_signature_invalid_message">署名されていないモジュールは不完全な可能性があります。デバイスを保護するため、このモジュールのインストールをブロックしました。</string>
     <string name="module_signature_verification_failed">署名されていないモジュールは不完全な可能性があります。不明な発行元のモジュールをこのデバイスにインストールすることを許可しますか？</string>

--- a/manager/app/src/main/res/values-ru/strings.xml
+++ b/manager/app/src/main/res/values-ru/strings.xml
@@ -617,7 +617,7 @@
     <string name="module_verified">Проверенные</string>
     <string name="module_signature_verified">Подпись модуля подтверждена</string>
     <string name="module_signature_verification">Подтверждение подписи</string>
-    <string name="module_signature_verification_summary">Принудительная проверка подписи при установке модулей. (доступно только для arm64-v8a)</string>
+    <string name="module_signature_verification_summary">При установке модуля принудительно проверять подпись. (Только для архитектуры ARM)</string>
     <string name="module_signature_invalid">Неизвестный издатель</string>
     <string name="module_signature_invalid_message">Неподписанные модули могут быть неполными. Для защиты устройства установка этого модуля была заблокирована.</string>
     <string name="module_signature_verification_failed">Неподписанные модули могут быть неполными. Вы хотите разрешить установку на этом устройстве следующего модуля от неизвестного издателя?</string>

--- a/manager/app/src/main/res/values-tr/strings.xml
+++ b/manager/app/src/main/res/values-tr/strings.xml
@@ -619,7 +619,7 @@ etkin: Çekirdekteki AVC günlük kaydında, \'su\' komutuna ait tcontext\'i \'k
     <string name="module_verified">Doğrulandı</string>
     <string name="module_signature_verified">Modül imzası doğrulandı</string>
     <string name="module_signature_verification">İmza Doğrulaması</string>
-    <string name="module_signature_verification_summary">Modülleri kurarken imza doğrulamasını zorunlu kıl. (Yalnızca arm64-v8a için geçerlidir)</string>
+    <string name="module_signature_verification_summary">Modüller yüklendiğinde imza doğrulamasını zorunlu kıl. (Sadece ARM mimarisi için geçerlidir)</string>
     <string name="module_signature_invalid">Bilinmeyen yayıncı</string>
     <string name="module_signature_invalid_message">İmzasız modüller eksik veya değiştirilmiş olabilir. Cihazınızı korumak için bu modülün kurulumu engellenmiştir.</string>
     <string name="module_signature_verification_failed">İmzasız modüller eksik veya değiştirilmiş olabilir. Bilinmeyen bir yayıncıdan gelen aşağıdaki modülün bu cihaza kurulmasına izin vermek istiyor musunuz?</string>

--- a/manager/app/src/main/res/values-vi/strings.xml
+++ b/manager/app/src/main/res/values-vi/strings.xml
@@ -619,7 +619,7 @@ Bật: Kích hoạt tính năng giả mạo sus tcontext của \'su\' thành \'k
     <string name="module_verified">Đã xác minh</string>
     <string name="module_signature_verified">Chữ ký module đã được xác minh</string>
     <string name="module_signature_verification">Xác minh chữ ký</string>
-    <string name="module_signature_verification_summary">Buộc xác minh chữ ký khi cài đặt module (Chỉ khả dụng cho arm64-v8a)</string>
+    <string name="module_signature_verification_summary">Buộc xác minh chữ ký khi cài đặt module (Chỉ khả dụng cho kiến trúc ARM)</string>
     <string name="module_signature_invalid">Tác giả không xác định</string>
     <string name="module_signature_invalid_message">Các module chưa được ký có thể chưa hoàn chỉnh. Để bảo vệ thiết bị của bạn, module này đã bị chặn cài đặt</string>
     <string name="module_signature_verification_failed">Các module chưa được ký có thể chưa hoàn chỉnh. Bạn có muốn cài đặt module này từ một tác giả chưa xác định không?</string>

--- a/manager/app/src/main/res/values-zh-rCN/strings.xml
+++ b/manager/app/src/main/res/values-zh-rCN/strings.xml
@@ -617,7 +617,7 @@
     <string name="module_verified">已验证</string>
     <string name="module_signature_verified">模块签名已验证</string>
     <string name="module_signature_verification">验证签名</string>
-    <string name="module_signature_verification_summary">模块安装时，强制验证签名。（仅 arm64-v8a 可用）</string>
+    <string name="module_signature_verification_summary">模块安装时，强制验证签名。（仅 ARM架构 可用）</string>
     <string name="module_signature_invalid">未知发布者</string>
     <string name="module_signature_invalid_message">未经签名的模块可能不完整。为了对设备进行保护，已阻止安装此模块。</string>
     <string name="module_signature_verification_failed">未经签名的模块可能不完整。你想安装来自未知发布者的模块吗？</string>

--- a/manager/app/src/main/res/values-zh-rHK/strings.xml
+++ b/manager/app/src/main/res/values-zh-rHK/strings.xml
@@ -586,4 +586,5 @@
     <!-- 循环路径相关 -->
     <!-- 循环路径功能描述 -->
     <!-- 模块签名功能描述 -->
+    <string name="module_signature_verification_summary">模組安裝嗰陣，會強制驗證個簽名。（淨係 ARM架構 用得）</string>
 </resources>

--- a/manager/app/src/main/res/values-zh-rHK/strings.xml
+++ b/manager/app/src/main/res/values-zh-rHK/strings.xml
@@ -585,6 +585,23 @@
     <string name="home_zygisk_implement">Zygisk 實現</string>
     <!-- 循环路径相关 -->
     <!-- 循环路径功能描述 -->
+    <string name="sus_loop_path_feature_label">SuS 循環路徑</string>
+    <string name="sus_loop_paths_description_title">循環路徑配置</string>
+    <string name="sus_loop_paths_description_text">循環路徑會喺每次非 root 用戶應用程式或者隔離服務啟動時，重新標記做 SUS_PATH。咁樣可以解決因為 inode 狀態重設或者核心重新建立 inode 而令到添加嘅路徑失效嘅問題。</string>
+    <string name="avc_log_spoofing">AVC 日誌欺騙</string>
+    <string name="avc_log_spoofing_enabled">AVC 日誌欺騙已經啟用</string>
+    <string name="avc_log_spoofing_disabled">AVC 日誌欺騙已經禁用</string>
+    <string name="avc_log_spoofing_description">禁用：喺核心 AVC 日誌入面禁用對 \'su\' 嘅 sus tcontext 進行欺騙。\n
+啟用：喺核心 AVC 日誌入面將 \'su\' 嘅 sus tcontext 欺騙成 \'kernel\'。</string>
+    <string name="avc_log_spoofing_warning">重要提示：\n
+- 核心入面嘅預設設定係 \'0\'。\n
+- 啟用呢個功能有時會令到開發人員喺除錯權限或者 SELinux 問題嗰陣難以搵出原因，所以建議用戶喺除錯時禁用呢個功能。</string>
     <!-- 模块签名功能描述 -->
+    <string name="module_verified">已驗證</string>
+    <string name="module_signature_verified">模組簽名已驗證</string>
+    <string name="module_signature_verification">驗證簽名</string>
     <string name="module_signature_verification_summary">模組安裝嗰陣，會強制驗證個簽名。（淨係 ARM架構 用得）</string>
+    <string name="module_signature_invalid">未知發布者</string>
+    <string name="module_signature_invalid_message">未經簽名嘅模組可能唔完整。為咗保護設備，已經阻止安裝呢個模組。</string>
+    <string name="module_signature_verification_failed">未經簽名嘅模組可能唔完整。你想唔想安裝嚟自未知發布者嘅模組？</string>
 </resources>

--- a/manager/app/src/main/res/values-zh-rTW/strings.xml
+++ b/manager/app/src/main/res/values-zh-rTW/strings.xml
@@ -617,7 +617,7 @@
     <string name="module_verified">已驗證</string>
     <string name="module_signature_verified">模組簽名已驗證</string>
     <string name="module_signature_verification">驗證簽名</string>
-    <string name="module_signature_verification_summary">模組安裝時，強制驗證簽名。（僅 arm64-v8a 可用）</string>
+    <string name="module_signature_verification_summary">模組安裝時，強制驗證簽名。（僅 ARM架構 可用）</string>
     <string name="module_signature_invalid">未知發布者</string>
     <string name="module_signature_invalid_message">未經簽名的模組可能不完整。為了對設備進行保護，已阻止安裝此模組。</string>
     <string name="module_signature_verification_failed">未經簽名的模組可能不完整。你想安裝來自未知發布者的模組嗎？</string>

--- a/manager/app/src/main/res/values-zh-rTW/strings.xml
+++ b/manager/app/src/main/res/values-zh-rTW/strings.xml
@@ -621,4 +621,5 @@
     <string name="module_signature_invalid">未知發布者</string>
     <string name="module_signature_invalid_message">未經簽名的模組可能不完整。為了對設備進行保護，已阻止安裝此模組。</string>
     <string name="module_signature_verification_failed">未經簽名的模組可能不完整。你想安裝來自未知發布者的模組嗎？</string>
+     <string name="home_hook_type">鉤子類型</string>
 </resources>

--- a/manager/app/src/main/res/values/strings.xml
+++ b/manager/app/src/main/res/values/strings.xml
@@ -625,7 +625,7 @@ Important Note:\n
     <string name="module_verified">Validated</string>
     <string name="module_signature_verified">Module signature verified</string>
     <string name="module_signature_verification">Signature Verification</string>
-    <string name="module_signature_verification_summary">Force signature verification when installing modules. (Only available for arm64-v8a)</string>
+    <string name="module_signature_verification_summary">Force signature verification when installing modules. (Only available for ARM architecture</string>
     <string name="module_signature_invalid">Unknown publisher</string>
     <string name="module_signature_invalid_message">Unsigned modules may be incomplete. To protect your device, installation of this module has been blocked.</string>
     <string name="module_signature_verification_failed">Unsigned modules may be incomplete. Do you want to allow the following module from an unknown publisher to install in this device?</string>


### PR DESCRIPTION
Revised the 'module_signature_verification_summary' string in multiple languages to clarify that forced signature verification applies to all ARM architectures, not just arm64-v8a. This change was made to accommodate a new update.