### PR TITLE
kernel： Handle unmount for isolated process correctly

### DIFF
--- a/kernel/core_hook.c
+++ b/kernel/core_hook.c
@@ -64,7 +64,7 @@ static inline bool is_allow_su()
 	return ksu_is_allow_uid(current_uid().val);
 }
 
-static inline bool is_unsupported_uid(uid_t uid)
+static inline bool is_unsupported_app_uid(uid_t uid)
 {
 #define LAST_APPLICATION_UID 19999
 	uid_t appid = uid % 100000;
@@ -622,14 +622,14 @@ int ksu_handle_prctl(int option, unsigned long arg2, unsigned long arg3,
 	return 0;
 }
 
-static bool is_appuid(kuid_t uid)
+static bool is_non_appuid(kuid_t uid)
 {
 #define PER_USER_RANGE 100000
 #define FIRST_APPLICATION_UID 10000
 #define LAST_APPLICATION_UID 19999
 
 	uid_t appid = uid.val % PER_USER_RANGE;
-	return appid >= FIRST_APPLICATION_UID && appid <= LAST_APPLICATION_UID;
+	return appid < FIRST_APPLICATION_UID;
 }
 
 static bool should_umount(struct path *path)
@@ -696,43 +696,52 @@ int ksu_handle_setuid(struct cred *new, const struct cred *old)
 	kuid_t new_uid = new->uid;
 	kuid_t old_uid = old->uid;
 
+	// old process is not root, ignore it.
 	if (0 != old_uid.val) {
-		// old process is not root, ignore it.
 		return 0;
 	}
 
-	if (!is_appuid(new_uid) || is_unsupported_uid(new_uid.val)) {
-		// pr_info("handle setuid ignore non application or isolated uid: %d\n", new_uid.val);
+	if (is_non_appuid(new_uid)) {
+	#ifdef CONFIG_KSU_DEBUG
+		pr_info("handle setuid ignore non application uid: %d\n", new_uid.val);
+	#endif
 		return 0;
 	}
 
 	if (ksu_is_allow_uid(new_uid.val)) {
-		// pr_info("handle setuid ignore allowed application: %d\n", new_uid.val);
+	#ifdef CONFIG_KSU_DEBUG
+		pr_info("handle setuid ignore allowed application: %d\n", new_uid.val);
+	#endif
 		return 0;
 	}
 
-	if (!ksu_uid_should_umount(new_uid.val)) {
+	// isolated process may be directly forked from zygote, always unmount
+	bool should_umount = is_unsupported_app_uid(new_uid.val) || ksu_uid_should_umount(new_uid.val);
+
+	if (!should_umount) {
+		// 若不需umount则直接返回
+	#ifdef CONFIG_KSU_DEBUG
+		pr_info("uid: %d should not umount!\n", new_uid.val);
+	#endif
 		return 0;
-	} else {
-#ifdef CONFIG_KSU_DEBUG
-		pr_info("uid: %d should not umount!\n", current_uid().val);
-#endif
 	}
 
 	// check old process's selinux context, if it is not zygote, ignore it!
 	// because some su apps may setuid to untrusted_app but they are in global mount namespace
 	// when we umount for such process, that is a disaster!
-	bool is_zygote_child = is_zygote(old->security);
-	if (!is_zygote_child) {
-		pr_info("handle umount ignore non zygote child: %d\n",
-			current->pid);
+	if (!is_zygote(old->security)) {
+		pr_info("handle umount ignore non zygote child: %d\n", current->pid);
 		return 0;
 	}
-#ifdef CONFIG_KSU_DEBUG
+
+	// 所有条件满足，执行 umount
+	#ifdef CONFIG_KSU_DEBUG
+	if (is_unsupported_app_uid(new_uid.val)) {
+		pr_info("handle umount for unsupported application uid: %d\n", new_uid.val);
+	}
 	// umount the target mnt
-	pr_info("handle umount for uid: %d, pid: %d\n", new_uid.val,
-		current->pid);
-#endif
+	pr_info("handle umount for uid: %d, pid: %d\n", new_uid.val, current->pid);
+	#endif
 
 	// fixme: use `collect_mounts` and `iterate_mount` to iterate all mountpoint and
 	// filter the mountpoint whose target is `/data/adb`


### PR DESCRIPTION
[原创作者PR说明](https://github.com/tiann/KernelSU/pull/2696)(翻译版):隔离进程可以直接从 zygote 衍生（fork），但目前的代码没有很好地处理它。如果隔离进程是从 zygote 衍生出来的，应该无条件地进行卸载，以此来修复这个问题。 我认为这给某些模块带来了麻烦。与 Magisk 不同的是，类 KSU 都没有一个用户空间守护进程 (userspace daemon) 来将隔离进程与应用进行匹配。

我的修改: 簡化條件分支, 修改运行流程(方便二次修改), 优化注释. 反正改了，但该得不多

[测试可成功 Build](https://github.com/HSSkyBoy/SukiSU-Ultra/actions)