### PR TITLE
kernel: Remove unnecessary strip in CONFIG_KSU_TRACEPOINT_HOOK check

### DIFF
--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -9,7 +9,7 @@ kernelsu-objs += ksud.o
 kernelsu-objs += embed_ksud.o
 kernelsu-objs += kernel_compat.o
 
-ifeq ($(strip $(CONFIG_KSU_TRACEPOINT_HOOK)),y)
+ifeq ($(CONFIG_KSU_TRACEPOINT_HOOK), y)
 kernelsu-objs += ksu_trace.o
 endif
 


### PR DESCRIPTION
The 'strip' function is redundant when checking Kconfig variables, as values from CONFIG options (like CONFIG_KSU_TRACEPOINT_HOOK) are already trimmed and do not contain leading/trailing whitespace.

Simplify the condition for better readability and maintainability:
  - Remove unnecessary $(strip ...)
  - Add consistent spacing around the comma

This change aligns with kernel Makefile conventions and improves code clarity without altering behavior.