### PR TITLE
kernel: define ksu_core_exit() for <4.1 devices without LSM hooks

### DIFF
--- a/kernel/core_hook.c
+++ b/kernel/core_hook.c
@@ -1076,4 +1076,7 @@ void __init ksu_core_init(void)
 {
 	pr_info("ksu_core_init: LSM hooks not in use.\n");
 }
+void ksu_core_exit(void)
+{
+}
 #endif //CONFIG_KSU_LSM_SECURITY_HOOKS


### PR DESCRIPTION
Ensure ksu_core_exit() is defined even if CONFIG_KSU_LSM_SECURITY_HOOKS is disabled, which is mostly relevant for kernels 4.1 and older, preventing build failures due to missing exit function.