### PR TITLE
kernel: fix undefined reference to `ksu_is_compat' in some integrated non-GKI kernel source

### DIFF
--- a/kernel/ksud.c
+++ b/kernel/ksud.c
@@ -63,9 +63,7 @@ u32 ksu_devpts_sid;
 // Detect whether it is on or not
 static bool is_boot_phase = true;
 
-#ifdef CONFIG_COMPAT
 bool ksu_is_compat __read_mostly = false;
-#endif
 
 void on_post_fs_data(void)
 {


### PR DESCRIPTION
Remove CONFIG_COMPAT conditional compilation for ksu_is_compat variable declaration to fix linker errors in LTO builds when CONFIG_COMPAT is disabled or unset.

The ksu_is_compat variable is referenced unconditionally in kernel/selinux/rules.c but was only defined when CONFIG_COMPAT was enabled, causing "undefined reference to 'ksu_is_compat'" errors during the LTO linking stage of kernel compilation.

Fixes #346