### PR TITLE
Add zakosign disable switch

### DIFF
--- a/manager/app/src/main/java/com/sukisu/ultra/ui/screen/Module.kt
+++ b/manager/app/src/main/java/com/sukisu/ultra/ui/screen/Module.kt
@@ -176,6 +176,7 @@ fun ModuleScreen(navigator: DestinationsNavigator) {
                 if (confirmResult == ConfirmResult.Confirmed) {
                     // 验证模块签名
                     val forceVerification = prefs.getBoolean("force_signature_verification", false)
+                    val disableVerification = prefs.getBoolean("dont_signature_verification", false)
                     val verificationResults = mutableMapOf<Uri, Boolean>()
 
                     for (uri in selectedModules) {
@@ -184,7 +185,17 @@ fun ModuleScreen(navigator: DestinationsNavigator) {
                         // 存储验证状态
                         setModuleVerificationStatus(uri, isVerified)
 
-                        if (forceVerification && !isVerified) {
+                        if (disableVerification) {
+                            try {
+                                navigator.navigate(FlashScreenDestination(FlashIt.FlashModules(selectedModules)))
+                                viewModel.markNeedRefresh()
+                            } catch (e: Exception) {
+                                Log.e("ModuleScreen", "Error navigating to FlashScreen: ${e.message}")
+                                scope.launch {
+                                    snackBarHost.showSnackbar("Error while installing module: ${e.message}")
+                                }
+                            }
+                        } else if (forceVerification && !isVerified) {
                             withContext(Dispatchers.Main) {
                                 signatureDialogMessage = context.getString(R.string.module_signature_invalid_message)
                                 isForceVerificationFailed = true

--- a/manager/app/src/main/java/com/sukisu/ultra/ui/screen/Settings.kt
+++ b/manager/app/src/main/java/com/sukisu/ultra/ui/screen/Settings.kt
@@ -173,8 +173,30 @@ fun SettingScreen(navigator: DestinationsNavigator) {
                             summary = stringResource(R.string.module_signature_verification_summary),
                             checked = forceSignatureVerification,
                             onCheckedChange = { enabled ->
-                                prefs.edit { putBoolean("force_signature_verification", enabled) }
                                 forceSignatureVerification = enabled
+                                prefs.edit { putBoolean("force_signature_verification", enabled) }
+                                // 如果开启强制验证，则关闭不验证选项
+                                if (enabled) {
+                                    prefs.edit { putBoolean("dont_signature_verification", false) }
+                                }
+                            }
+                        )
+                        // 不验证签名开关
+                        var dontSignatureVerification by rememberSaveable {
+                            mutableStateOf(prefs.getBoolean("dont_signature_verification", false))
+                        }
+                        SwitchItem(
+                            icon = Icons.Filled.RemoveModerator,
+                            title = stringResource(R.string.module_signature_not_verification),
+                            summary = stringResource(R.string.module_signature_not_verification_summary),
+                            checked = dontSignatureVerification,
+                            onCheckedChange = { enabled ->
+                                dontSignatureVerification = enabled
+                                prefs.edit { putBoolean("dont_signature_verification", enabled) }
+                                // 如果开启不验证，则关闭强制验证选项
+                                if (enabled) {
+                                    prefs.edit { putBoolean("force_signature_verification", false) }
+                                }
                             }
                         )
                     }

--- a/manager/app/src/main/res/values-zh-rCN/strings.xml
+++ b/manager/app/src/main/res/values-zh-rCN/strings.xml
@@ -616,6 +616,8 @@
     <string name="module_signature_verified">模块签名已验证</string>
     <string name="module_signature_verification">验证签名</string>
     <string name="module_signature_verification_summary">模块安装时，强制验证签名。（仅 ARM架构 可用）</string>
+    <string name="module_signature_not_verification">不验证签名</string>
+    <string name="module_signature_not_verification_summary">模块安装时，不验证签名。</string>
     <string name="module_signature_invalid">未知发布者</string>
     <string name="module_signature_invalid_message">未经签名的模块可能不完整。为了对设备进行保护，已阻止安装此模块。</string>
     <string name="module_signature_verification_failed">未经签名的模块可能不完整。你想安装来自未知发布者的模块吗？</string>

--- a/manager/app/src/main/res/values/strings.xml
+++ b/manager/app/src/main/res/values/strings.xml
@@ -624,6 +624,8 @@ Important Note:\n
     <string name="module_signature_verified">Module signature verified</string>
     <string name="module_signature_verification">Signature Verification</string>
     <string name="module_signature_verification_summary">Force signature verification when installing modules (Only available for ARM architecture)</string>
+    <string name="module_signature_not_verification">Do not verify signature</string>
+    <string name="module_signature_not_verification_summary">When installing the module, do not verify the signature.</string>
     <string name="module_signature_invalid">Unknown publisher</string>
     <string name="module_signature_invalid_message">Unsigned modules may be incomplete. To protect your device, installation of this module has been blocked</string>
     <string name="module_signature_verification_failed">Unsigned modules may be incomplete. Do you want to allow the following module from an unknown publisher to install in this device?</string>


### PR DESCRIPTION
This is important to me because many modules do not use zakosign signatures.

I think the pop-up prompts in the SukiSU manager are not good, as this requires an extra click every time I install a module, making me feel annoyed.