### PR TITLE
feat: detect proc_ops support via header parsing instead of version c…

### DIFF
--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -175,4 +175,9 @@ else
 $(info -- You have not integrated susfs in your kernel yet.)
 $(info -- Read: https://gitlab.com/simonpunk/susfs4ksu)
 endif
+
+# Function proc_ops check
+ifeq ($(shell grep -q "struct proc_ops " $(srctree)/include/linux/proc_fs.h; echo $$?),0)
+ccflags-y += -DKSU_COMPAT_HAS_PROC_OPS
+endif
 # Keep a new line here!! Because someone may append config

--- a/kernel/throne_comm.c
+++ b/kernel/throne_comm.c
@@ -78,7 +78,7 @@ static ssize_t uid_scanner_write(struct file *file, const char __user *buffer,
 	return count;
 }
 
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,6,0)
+#ifdef KSU_COMPAT_HAS_PROC_OPS
 static const struct proc_ops uid_scanner_proc_ops = {
 	.proc_open = uid_scanner_open,
 	.proc_read = seq_read,


### PR DESCRIPTION
Some kernels (e.g. 5.4 with backports) include proc_ops despite being older than 5.6.0. Replace hardcoded version check with runtime header detection to handle these cases.

- Check for "struct proc_ops" in include/linux/proc_fs.h
- Use KSU_COMPAT_HAS_PROC_OPS macro for conditional compilation
- Fixes build failures on kernels with backported proc_ops