### PR TITLE
kernel: core_hook: add config guard for manual SU escalation

### DIFF
--- a/kernel/core_hook.c
+++ b/kernel/core_hook.c
@@ -729,6 +729,7 @@ skip_check:
 		return 0;
 	}
 
+#ifdef CONFIG_KSU_MANUAL_SU
 	if (arg2 == CMD_SU_ESCALATION_REQUEST) {
 		uid_t target_uid = (uid_t)arg3;
 		struct su_request_arg __user *user_req = (struct su_request_arg __user *)arg4;
@@ -767,6 +768,7 @@ skip_check:
 			pr_err("prctl: CMD_ADD_PENDING_ROOT reply error\n");
 		return 0;
 	}
+#endif
 
 
 	// all other cmds are for 'root manager'


### PR DESCRIPTION
Wrap manual SU escalation handling in CONFIG_KSU_MANUAL_SU conditional compilation to allow builds without this functionality.

This affects:
- CMD_SU_ESCALATION_REQUEST
- CMD_ADD_PENDING_ROOT

When CONFIG_KSU_MANUAL_SU is disabled, these prctl commands will not be compiled into the kernel.