### PR TITLE
docs: Sync TRACEPOINT HOOK v1.1

### DIFF
--- a/docs/guide/tracepoint-hook.md
+++ b/docs/guide/tracepoint-hook.md
@@ -44,7 +44,7 @@ Generally need to modify the `do_execve` and `compat_do_execve` methods in `fs/e
  		.ptr.compat = __envp,
  	};
 +#if defined(CONFIG_KSU) && defined(CONFIG_KSU_TRACEPOINT_HOOK)
-+    trace_ksu_trace_execveat_sucompat_hook((int *)AT_FDCWD, &filename, NULL, NULL, NULL); /* 32-bit su */
++    trace_ksu_trace_execveat_hook((int *)AT_FDCWD, &filename, &argv, &envp, 0)); // 32-bit su and 32-on-64 support
 +#endif
  	return do_execveat_common(AT_FDCWD, filename, argv, envp, 0);
  }
@@ -236,35 +236,4 @@ Need to modify the `input_event` method in `drivers/input/input.c`, not `input_h
  	if (is_event_supported(type, dev->evbit, EV_MAX)) {
  
  		spin_lock_irqsave(&dev->event_lock, flags);
-```
-
-### devpts Hook (`pty.c`)
-
-Need to modify the `pts_unix98_lookup` method in `drivers/tty/pty.c`
-
-```patch
---- a/drivers/tty/pty.c
-+++ b/drivers/tty/pty.c
-@@ -31,6 +31,10 @@
- #include <linux/compat.h>
- #include "tty.h"
- 
-+#if defined(CONFIG_KSU) && defined(CONFIG_KSU_TRACEPOINT_HOOK)
-+#include <../../drivers/kernelsu/ksu_trace.h>
-+#endif
-+
- #undef TTY_DEBUG_HANGUP
- #ifdef TTY_DEBUG_HANGUP
- # define tty_debug_hangup(tty, f, args...)	tty_debug(tty, f, ##args)
-@@ -707,6 +711,10 @@ static struct tty_struct *pts_unix98_lookup(struct tty_driver *driver,
- {
- 	struct tty_struct *tty;
- 
-+#if defined(CONFIG_KSU) && defined(CONFIG_KSU_TRACEPOINT_HOOK)
-+		trace_ksu_trace_devpts_hook((struct inode *)file->f_path.dentry->d_inode);
-+#endif
-+
- 	mutex_lock(&devpts_mutex);
- 	tty = devpts_get_priv(file->f_path.dentry);
- 	mutex_unlock(&devpts_mutex);
 ```

--- a/docs/zh/guide/tracepoint-hook.md
+++ b/docs/zh/guide/tracepoint-hook.md
@@ -44,7 +44,7 @@
  		.ptr.compat = __envp,
  	};
 +#if defined(CONFIG_KSU) && defined(CONFIG_KSU_TRACEPOINT_HOOK)
-+    trace_ksu_trace_execveat_sucompat_hook((int *)AT_FDCWD, &filename, NULL, NULL, NULL); /* 32-bit su */
++    trace_ksu_trace_execveat_hook((int *)AT_FDCWD, &filename, &argv, &envp, 0)); // 32-bit su and 32-on-64 support
 +#endif
  	return do_execveat_common(AT_FDCWD, filename, argv, envp, 0);
  }
@@ -236,35 +236,4 @@
  	if (is_event_supported(type, dev->evbit, EV_MAX)) {
  
  		spin_lock_irqsave(&dev->event_lock, flags);
-```
-
-### devpts 钩子 (`pty.c`)
-
-需要修改 `drivers/tty/pty.c` 的 `pts_unix98_lookup` 方法
-
-```patch
---- a/drivers/tty/pty.c
-+++ b/drivers/tty/pty.c
-@@ -31,6 +31,10 @@
- #include <linux/compat.h>
- #include "tty.h"
- 
-+#if defined(CONFIG_KSU) && defined(CONFIG_KSU_TRACEPOINT_HOOK)
-+#include <../../drivers/kernelsu/ksu_trace.h>
-+#endif
-+
- #undef TTY_DEBUG_HANGUP
- #ifdef TTY_DEBUG_HANGUP
- # define tty_debug_hangup(tty, f, args...)	tty_debug(tty, f, ##args)
-@@ -707,6 +711,10 @@ static struct tty_struct *pts_unix98_lookup(struct tty_driver *driver,
- {
- 	struct tty_struct *tty;
- 
-+#if defined(CONFIG_KSU) && defined(CONFIG_KSU_TRACEPOINT_HOOK)
-+		trace_ksu_trace_devpts_hook((struct inode *)file->f_path.dentry->d_inode);
-+#endif
-+
- 	mutex_lock(&devpts_mutex);
- 	tty = devpts_get_priv(file->f_path.dentry);
- 	mutex_unlock(&devpts_mutex);
 ```


### PR DESCRIPTION
- Replace trace_ksu_trace_execveat_sucompat_hook with trace_ksu_trace_execveat_hook to align with v1.1 changes The new hook now passes argv/envp and a flags argument, adding support for 32-on-64 environments.
- Remove the devpts hook section from both English and Chinese guides The devpts (pty.c) hook example was deprecated in v1.1 and is no longer required.

Link: https://github.com/SukiSU-Ultra/SukiSU-Ultra/commit/f1f7c61aeea8357c583f68558801185cba8f1cdd