### PR TITLE
KernelSU: add rtc_time compatibility for older kernels

### DIFF
--- a/kernel/sulog.c
+++ b/kernel/sulog.c
@@ -14,6 +14,22 @@
 #include <linux/spinlock.h>
 #include <linux/crc32.h>
 
+#ifndef time64_to_tm
+#include <linux/rtc.h>
+static inline void time64_to_tm(time64_t totalsecs, int offset, struct tm *result)
+{
+    struct rtc_time rtc_tm;
+    rtc_time64_to_tm(totalsecs, &rtc_tm);
+
+    result->tm_sec  = rtc_tm.tm_sec;
+    result->tm_min  = rtc_tm.tm_min;
+    result->tm_hour = rtc_tm.tm_hour;
+    result->tm_mday = rtc_tm.tm_mday;
+    result->tm_mon  = rtc_tm.tm_mon;
+    result->tm_year = rtc_tm.tm_year;
+}
+#endif
+
 #include "klog.h"
 #include "kernel_compat.h"
 #include "sulog.h"


### PR DESCRIPTION
Some older kernels lack a full definition of `struct rtc_time`, causing
sulog build failure when calling `time64_to_tm`. This patch adds an
explicit include of <linux/rtc.h> and a small compatibility layer to
ensure `time64_to_tm` and related structures are properly resolved
across different kernel versions.