### PR TITLE
add rtc_time compatibility for older kernels

### DIFF
--- a/kernel/sulog.c
+++ b/kernel/sulog.c
@@ -14,8 +14,11 @@
 #include <linux/spinlock.h>
 #include <linux/crc32.h>
 
-#ifndef time64_to_tm
+#if __has_include(<linux/rtc.h>)
 #include <linux/rtc.h>
+#endif
+
+#ifndef time64_to_tm
 static inline void time64_to_tm(time64_t totalsecs, int offset, struct tm *result)
 {
     struct rtc_time rtc_tm;


### PR DESCRIPTION
Some older kernels lack a full definition of `struct rtc_time`, causing
sulog build failure when calling `time64_to_tm`. This patch adds an
explicit include of <linux/rtc.h> and a small compatibility layer to
ensure `time64_to_tm` and related structures are properly resolved
across different kernel versions.