### PR TITLE
kernel: Fix compilation

### DIFF
--- a/kernel/pkg_observer.c
+++ b/kernel/pkg_observer.c
@@ -70,8 +70,12 @@ static int add_mark_on_inode(struct inode *inode, u32 mask,
     fsnotify_init_mark(m, g);
     m->mask = mask;
     ret = fsnotify_add_inode_mark(m, inode, 0);
+#elif LINUX_VERSION_CODE >= KERNEL_VERSION(4, 11, 0)
+    fsnotify_init_mark(m, g);
+    m->mask = mask;
+    ret = fsnotify_add_mark(m, inode, NULL, 0);
 #else
-    fsnotify_init_mark(m, m_free);
+    fsnotify_init_mark(m, g, m_free);
     m->mask = mask;
     ret = fsnotify_add_mark(m, g, inode, NULL, 0);
 #endif


### PR DESCRIPTION
The definiton of fsnotify_add_mark changed multiple times, once in 4.11-rc2, once in 6.9-rc1, so older kernels still need to fix.