### PR TITLE
Changed #ifdef CONFIG_KSU_SUSFS to CONFIG_KSU_SUSFS_SUS_MOUNT

### DIFF
--- a/kernel/selinux/selinux.c
+++ b/kernel/selinux/selinux.c
@@ -163,7 +163,7 @@ bool is_zygote(void *sec)
     return result;
 }
 
-#ifdef CONFIG_KSU_SUSFS
+#ifdef CONFIG_KSU_SUSFS_SUS_MOUNT
 static inline void susfs_set_sid(const char *secctx_name, u32 *out_sid)
 {
     int err;


### PR DESCRIPTION
Updated CONFIG_KSU_SUSFS to CONFIG_KSU_SUSFS_SUS_MOUNT to match the declarations in selinux.h and resolve build error in namespace.c for undeclared function (issue #536 )