### PR TITLE
chore(ksud): bump ksud's deps

### DIFF
--- a/userspace/ksud/Cargo.lock
+++ b/userspace/ksud/Cargo.lock
@@ -3,37 +3,16 @@
 version = 4
 
 [[package]]
-name = "addr2line"
-version = "0.24.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
-dependencies = [
- "gimli",
-]
-
-[[package]]
 name = "adler2"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "adler32"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aae1277d39aeec15cb388266ecc24b11c80469deae6067e17a1a7aa9e5c1f234"
-
-[[package]]
-name = "ahash"
-version = "0.8.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
-dependencies = [
- "cfg-if",
- "once_cell",
- "version_check",
- "zerocopy",
-]
 
 [[package]]
 name = "allocator-api2"
@@ -48,12 +27,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc7eb209b1518d6bb87b283c20095f5228ecda460da70b44f0802523dea6da04"
 
 [[package]]
-name = "android-tzdata"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
-
-[[package]]
 name = "android_log-sys"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -61,9 +34,9 @@ checksum = "84521a3cf562bc62942e294181d9eef17eb38ceb8c68677bc49f144e4c3d4f8d"
 
 [[package]]
 name = "android_logger"
-version = "0.14.1"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05b07e8e73d720a1f2e4b6014766e6039fd2e96a4fa44e2a78d0e1fa2ff49826"
+checksum = "dbb4e440d04be07da1f1bf44fb4495ebd58669372fe0cffa6e48595ac5bd88a3"
 dependencies = [
  "android_log-sys",
  "env_filter",
@@ -81,9 +54,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.18"
+version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8acc5369981196006228e28809f761875c0327210a891e941f4c683b3a99529b"
+checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -96,85 +69,70 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.10"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
+checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b2d16507662817a6a20a9ea92df6652ee4f94f914589377d69f3b21bc5798a9"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
 dependencies = [
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.2"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.7"
+version = "3.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3534e77181a9cc07539ad51f2141fe32f6c3ffd4df76db8ad92346b003ae4e"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
- "once_cell",
- "windows-sys 0.59.0",
+ "once_cell_polyfill",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "anyhow"
-version = "1.0.98"
+version = "1.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
+checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 
 [[package]]
 name = "arbitrary"
-version = "1.4.1"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dde20b3d026af13f561bdd0f15edf01fc734f0dafcedbaf42bba506a9517f223"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
 dependencies = [
  "derive_arbitrary",
 ]
 
 [[package]]
 name = "async-trait"
-version = "0.1.88"
+version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e539d3fca749fcee5236ab05e93a52867dd549cc157c8cb7f99595f3cedffdb5"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.110",
 ]
 
 [[package]]
 name = "autocfg"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
-
-[[package]]
-name = "backtrace"
-version = "0.3.75"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6806a6321ec58106fea15becdad98371e28d92ccbc7c8f1b3b6dd724fe8f1002"
-dependencies = [
- "addr2line",
- "cfg-if",
- "libc",
- "miniz_oxide",
- "object",
- "rustc-demangle",
- "windows-targets 0.52.6",
-]
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "bitflags"
@@ -184,9 +142,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.8.0"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f68f53c83ab957f72c32642f3868eec03eb974d1fb82e453128456482613d36"
+checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
 
 [[package]]
 name = "block-buffer"
@@ -199,9 +157,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.17.0"
+version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
+checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 
 [[package]]
 name = "byteorder"
@@ -211,32 +169,34 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.10.1"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
+checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
 
 [[package]]
 name = "cc"
-version = "1.2.22"
+version = "1.2.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32db95edf998450acc7881c932f94cd9b05c87b4b2599e8bab064753da4acfd1"
+checksum = "b97463e1064cb1b1c1384ad0a0b9c8abd0988e2a91f52606c80ef14aadb63e36"
 dependencies = [
+ "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
 [[package]]
 name = "cfg-if"
-version = "1.0.0"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "chrono"
-version = "0.4.41"
+version = "0.4.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c469d952047f47f91b68d1cba3f10d63c11d73e4636f24f08daf0278abf01c4d"
+checksum = "145052bdd345b87320e369255277e3fb5152762ad123a901ef5c262dd38fe8d2"
 dependencies = [
- "android-tzdata",
  "iana-time-zone",
  "js-sys",
  "num-traits",
@@ -246,9 +206,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.38"
+version = "4.5.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed93b9805f8ba930df42c2590f05453d5ec36cbb85d018868a5b24d31f6ac000"
+checksum = "4c26d721170e0295f191a69bd9a1f93efcdb0aff38684b61ab5750468972e5f5"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -256,9 +216,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.38"
+version = "4.5.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "379026ff283facf611b0ea629334361c4211d1b12ee01024eec1591133b04120"
+checksum = "75835f0c7bf681bfd05abe44e965760fea999a5286c6eb2d59883634fd02011a"
 dependencies = [
  "anstream",
  "anstyle",
@@ -268,33 +228,33 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.32"
+version = "4.5.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09176aae279615badda0765c0c0b3f6ed53f4709118af73cf4655d85d1530cd7"
+checksum = "2a0b5487afeab2deb2ff4e03a807ad1a03ac532ff5a2cee5d86884440c7f7671"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.110",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.7.4"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
+checksum = "a1d728cc89cf3aee9ff92b05e62b19ee65a02b5702cff7d5a377e32c6ae29d8d"
 
 [[package]]
 name = "colorchoice"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
+checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "const_format"
-version = "0.2.34"
+version = "0.2.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "126f97965c8ad46d6d9163268ff28432e8f6a1196a55578867832e3049df63dd"
+checksum = "7faa7469a93a566e9ccc1c73fe783b4a65c274c5ace346038dca9c39fe0030ad"
 dependencies = [
  "const_format_proc_macros",
 ]
@@ -351,9 +311,9 @@ checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
 
 [[package]]
 name = "crc32fast"
-version = "1.4.2"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
 ]
@@ -416,9 +376,9 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crypto-common"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
  "typenum",
@@ -426,21 +386,21 @@ dependencies = [
 
 [[package]]
 name = "dary_heap"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04d2cd9c18b9f454ed67da600630b021a8a80bf33f8c95896ab33aaf1c26b728"
+checksum = "06d2e3287df1c007e74221c49ca10a95d557349e54b3a75dc2fb14712c751f04"
 
 [[package]]
 name = "deflate64"
-version = "0.1.9"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da692b8d1080ea3045efaab14434d40468c3d8657e42abddfffca87b428f4c1b"
+checksum = "26bf8fc351c5ed29b5c2f0cbbac1b209b74f60ecd62e675a998df72c49af5204"
 
 [[package]]
 name = "deranged"
-version = "0.4.0"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c9e6a11ca8224451684bc0d7d5a7adbf8f2fd6887261a1cfc3c0432f9d4068e"
+checksum = "ececcb659e7ba858fb4f10388c250a7252eb0a27373f1a72b8748afdd248e587"
 dependencies = [
  "powerfmt",
 ]
@@ -453,18 +413,18 @@ checksum = "2cdc8d50f426189eef89dac62fabfa0abb27d5cc008f25bf4156a0203325becc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.110",
 ]
 
 [[package]]
 name = "derive_arbitrary"
-version = "1.4.1"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30542c1ad912e0e3d22a1935c290e12e8a29d704a420177a31faad4a601a0800"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -494,9 +454,9 @@ dependencies = [
 
 [[package]]
 name = "env_filter"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "186e05a59d4c50738528153b83b0b0194d3a29507dfec16eccd4b342903397d0"
+checksum = "1bf3c259d255ca70051b30e2e95b5446cdb8949ac4cd22c0d7fd634d89f568e2"
 dependencies = [
  "log",
 ]
@@ -536,12 +496,12 @@ dependencies = [
 
 [[package]]
 name = "errno"
-version = "0.3.10"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -572,27 +532,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
-name = "filetime"
-version = "0.2.26"
+name = "find-msvc-tools"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc0505cd1b6fa6580283f6bdf70a73fcf4aba1184038c90902b92b3dd0df63ed"
-dependencies = [
- "cfg-if",
- "libc",
- "libredox",
- "windows-sys 0.60.2",
-]
+checksum = "3a3076410a55c90011c298b04d0cfa770b00fa04e1e3c97d3f6c9de105a03844"
 
 [[package]]
 name = "flate2"
-version = "1.1.1"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ced92e76e966ca2fd84c8f7aa01a4aea65b0eb6648d72f7c8f3e2764a67fece"
+checksum = "bfe33edd8e85a12a67454e37f8c75e730830d83e313556ab9ebf9ee7fbeb3bfb"
 dependencies = [
  "crc32fast",
  "libz-rs-sys",
  "miniz_oxide",
 ]
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "fsevent-sys"
@@ -615,46 +575,35 @@ dependencies = [
 
 [[package]]
 name = "getopts"
-version = "0.2.21"
+version = "0.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14dbbfd5c71d70241ecf9e6f13737f7b5ce823821063188d7e46c41d371eebd5"
+checksum = "cfe4fbac503b8d1f88e6676011885f34b7174f46e59956bba534ba83abded4df"
 dependencies = [
  "unicode-width",
 ]
 
 [[package]]
 name = "getrandom"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
- "wasi 0.14.2+wasi-0.2.4",
+ "wasip2",
 ]
 
 [[package]]
-name = "gimli"
-version = "0.31.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
-
-[[package]]
 name = "hashbrown"
-version = "0.14.5"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+checksum = "5419bdc4f6a9207fbeba6d11b604d481addf78ecd10c11ad51e76c2f6482748d"
 dependencies = [
- "ahash",
  "allocator-api2",
+ "equivalent",
+ "foldhash",
 ]
-
-[[package]]
-name = "hashbrown"
-version = "0.15.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
 
 [[package]]
 name = "heck"
@@ -679,9 +628,9 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.63"
+version = "0.1.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0c919e5debc312ad217002b8048a17b7d83f80703865bbfcfebb0458b0b27d8"
+checksum = "33e57f83510bb73707521ebaffa789ec8caf86f9657cad665b092b581d40e9fb"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
@@ -703,44 +652,58 @@ dependencies = [
 
 [[package]]
 name = "include-flate"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df49c16750695486c1f34de05da5b7438096156466e7f76c38fcdf285cf0113e"
+checksum = "e01b7cb6ca682a621e7cda1c358c9724b53a7b4409be9be1dd443b7f3a26f998"
 dependencies = [
  "include-flate-codegen",
- "lazy_static",
+ "include-flate-compress",
  "libflate",
+ "zstd",
 ]
 
 [[package]]
 name = "include-flate-codegen"
-version = "0.2.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c5b246c6261be723b85c61ecf87804e8ea4a35cb68be0ff282ed84b95ffe7d7"
+checksum = "4f49bf5274aebe468d6e6eba14a977eaf1efa481dc173f361020de70c1c48050"
 dependencies = [
+ "include-flate-compress",
  "libflate",
+ "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.110",
+ "zstd",
+]
+
+[[package]]
+name = "include-flate-compress"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eae6a40e716bcd5931f5dbb79cd921512a4f647e2e9413fded3171fca3824dbc"
+dependencies = [
+ "libflate",
+ "zstd",
 ]
 
 [[package]]
 name = "indexmap"
-version = "2.9.0"
+version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
+checksum = "6717a8d2a5a929a1a2eb43a12812498ed141a0bcfb7e8f7844fbdbe4303bba9f"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.2",
+ "hashbrown",
 ]
 
 [[package]]
 name = "inotify"
-version = "0.9.6"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8069d3ec154eb856955c1c0fbffefbf5f3c40a104ec912d4797314c1801abff"
+checksum = "f37dccff2791ab604f9babef0ba14fbe0be30bd368dc541e2b08d07c8aa908f3"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.10.0",
  "inotify-sys",
  "libc",
 ]
@@ -756,18 +719,18 @@ dependencies = [
 
 [[package]]
 name = "is_executable"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4a1b5bad6f9072935961dfbf1cced2f3d129963d091b6f69f007fe04e758ae2"
+checksum = "baabb8b4867b26294d818bf3f651a454b6901431711abb96e296245888d6e8c4"
 dependencies = [
- "winapi",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "is_terminal_polyfill"
-version = "1.70.1"
+version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itoa"
@@ -786,10 +749,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "js-sys"
-version = "0.3.77"
+name = "jobserver"
+version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom",
+ "libc",
+]
+
+[[package]]
+name = "js-sys"
+version = "0.3.82"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b011eec8cc36da2aab2d5cff675ec18454fad408585853910a202391cf9f8e65"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -857,7 +830,7 @@ dependencies = [
  "sha256",
  "tempfile",
  "which",
- "zip",
+ "zip 6.0.0",
  "zip-extensions",
 ]
 
@@ -869,15 +842,15 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.172"
+version = "0.2.177"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
+checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
 
 [[package]]
 name = "libflate"
-version = "2.1.0"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45d9dfdc14ea4ef0900c1cddbc8dcd553fbaacd8a4a282cf4018ae9dd04fb21e"
+checksum = "e3248b8d211bd23a104a42d81b4fa8bb8ac4a3b75e7a43d85d2c9ccb6179cd74"
 dependencies = [
  "adler32",
  "core2",
@@ -888,12 +861,12 @@ dependencies = [
 
 [[package]]
 name = "libflate_lz77"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6e0d73b369f386f1c44abd9c570d5318f55ccde816ff4b562fa452e5182863d"
+checksum = "a599cb10a9cd92b1300debcef28da8f70b935ec937f44fcd1b70a7c986a11c5c"
 dependencies = [
  "core2",
- "hashbrown 0.14.5",
+ "hashbrown",
  "rle-decode-fast",
 ]
 
@@ -902,17 +875,6 @@ name = "libm"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
-
-[[package]]
-name = "libredox"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "391290121bad3d37fbddad76d8f5d1c1c314cfc646d143d7e07a3086ddff0ce3"
-dependencies = [
- "bitflags 2.8.0",
- "libc",
- "redox_syscall",
-]
 
 [[package]]
 name = "libz-rs-sys"
@@ -931,15 +893,15 @@ checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.9.4"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
+checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
 name = "log"
-version = "0.4.27"
+version = "0.4.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
+checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
 
 [[package]]
 name = "lzma-rs"
@@ -949,6 +911,16 @@ checksum = "297e814c836ae64db86b36cf2a557ba54368d03f6afcd7d947c266692f71115e"
 dependencies = [
  "byteorder",
  "crc",
+]
+
+[[package]]
+name = "lzma-rust2"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c60a23ffb90d527e23192f1246b14746e2f7f071cb84476dd879071696c18a4a"
+dependencies = [
+ "crc",
+ "sha2",
 ]
 
 [[package]]
@@ -964,29 +936,30 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.7.4"
+version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3be647b768db090acb35d5ec5db2b0e1f1de11133ca123b9eacf5137868f892a"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
+ "simd-adler32",
 ]
 
 [[package]]
 name = "mio"
-version = "0.8.11"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
+checksum = "69d83b0086dc8ecf3ce9ae2874b2d1290252e2a30720bea58a5c6639b0092873"
 dependencies = [
  "libc",
  "log",
- "wasi 0.11.1+wasi-snapshot-preview1",
- "windows-sys 0.48.0",
+ "wasi",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1000,22 +973,27 @@ dependencies = [
 
 [[package]]
 name = "notify"
-version = "6.1.1"
+version = "8.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6205bd8bb1e454ad2e27422015fb5e4f2bcc7e08fa8f27058670d208324a4d2d"
+checksum = "4d3d07927151ff8575b7087f245456e549fea62edf0ec4e565a5ee50c8402bc3"
 dependencies = [
- "bitflags 2.8.0",
- "crossbeam-channel",
- "filetime",
+ "bitflags 2.10.0",
  "fsevent-sys",
  "inotify",
  "kqueue",
  "libc",
  "log",
  "mio",
+ "notify-types",
  "walkdir",
- "windows-sys 0.48.0",
+ "windows-sys 0.60.2",
 ]
+
+[[package]]
+name = "notify-types"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e0826a989adedc2a244799e823aece04662b66609d96af8dff7ac6df9a8925d"
 
 [[package]]
 name = "num-conv"
@@ -1033,19 +1011,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "object"
-version = "0.36.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "pin-project-lite"
@@ -1066,34 +1041,58 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
-name = "proc-macro2"
-version = "1.0.95"
+name = "proc-macro-error"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.103"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ee95bc4ef87b8d5ba32e8b7714ccc834865276eab0aed5c9958d00ec45f49e8"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.40"
+version = "1.0.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
+checksum = "a338cc41d27e6cc6dce6cefc13a0729dfbb81c262b1f519331575dd80ef3067f"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
 name = "r-efi"
-version = "5.2.0"
+version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rayon"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
+checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
 dependencies = [
  "either",
  "rayon-core",
@@ -1101,28 +1100,19 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.12.1"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
 ]
 
 [[package]]
-name = "redox_syscall"
-version = "0.5.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5407465600fb0548f1442edf71dd20683c6ed326200ace4b1ef0763521bb3b77"
-dependencies = [
- "bitflags 2.8.0",
-]
-
-[[package]]
 name = "regex-lite"
-version = "0.1.6"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53a49587ad06b26609c52e423de037e7f57f20d53535d66e08c695f347df952a"
+checksum = "8d942b98df5e658f56f20d592c7f868833fe38115e65c33003d8cd224b0155da"
 
 [[package]]
 name = "rle-decode-fast"
@@ -1132,9 +1122,9 @@ checksum = "3582f63211428f83597b51b2ddb88e2a91a9d52d12831f9d08f5e624e8977422"
 
 [[package]]
 name = "rust-embed"
-version = "8.7.2"
+version = "8.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "025908b8682a26ba8d12f6f2d66b987584a4a87bc024abc5bbc12553a8cd178a"
+checksum = "947d7f3fad52b283d261c4c99a084937e2fe492248cb9a68a8435a861b8798ca"
 dependencies = [
  "include-flate",
  "rust-embed-impl",
@@ -1144,40 +1134,34 @@ dependencies = [
 
 [[package]]
 name = "rust-embed-impl"
-version = "8.7.2"
+version = "8.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6065f1a4392b71819ec1ea1df1120673418bf386f50de1d6f54204d836d4349c"
+checksum = "5fa2c8c9e8711e10f9c4fd2d64317ef13feaab820a4c51541f1a8c8e2e851ab2"
 dependencies = [
  "proc-macro2",
  "quote",
  "rust-embed-utils",
- "syn",
+ "syn 2.0.110",
  "walkdir",
 ]
 
 [[package]]
 name = "rust-embed-utils"
-version = "8.7.2"
+version = "8.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6cc0c81648b20b70c491ff8cce00c1c3b223bb8ed2b5d41f0e54c6c4c0a3594"
+checksum = "60b161f275cb337fe0a44d924a5f4df0ed69c2c39519858f931ce61c779d3475"
 dependencies = [
  "sha2",
  "walkdir",
 ]
 
 [[package]]
-name = "rustc-demangle"
-version = "0.1.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
-
-[[package]]
 name = "rustix"
 version = "0.38.34"
-source = "git+https://github.com/Kernel-SU/rustix.git?branch=main#4a53fbc7cb7a07cabe87125cc21dbc27db316259"
+source = "git+https://github.com/Kernel-SU/rustix.git?rev=4a53fbc7cb7a07cabe87125cc21dbc27db316259#4a53fbc7cb7a07cabe87125cc21dbc27db316259"
 dependencies = [
- "bitflags 2.8.0",
- "errno 0.3.10",
+ "bitflags 2.10.0",
+ "errno 0.3.14",
  "itoa",
  "libc",
  "linux-raw-sys 0.4.15",
@@ -1187,22 +1171,22 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.0.7"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266"
+checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
 dependencies = [
- "bitflags 2.8.0",
- "errno 0.3.10",
+ "bitflags 2.10.0",
+ "errno 0.3.14",
  "libc",
- "linux-raw-sys 0.9.4",
- "windows-sys 0.59.0",
+ "linux-raw-sys 0.11.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "rustversion"
-version = "1.0.20"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "ryu"
@@ -1221,34 +1205,45 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.219"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.219"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.110",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.140"
+version = "1.0.145"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
+checksum = "402a6f66d8c709116cf22f558eab210f5a50187f702eb4d7e5ef38d9a7f1c79c"
 dependencies = [
  "itoa",
  "memchr",
  "ryu",
  "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -1306,9 +1301,19 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
-version = "2.0.101"
+version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ce2b7fc941b3a24138a0a7cf8e858bfc6a992e7978a068a5c760deb0ed43caf"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.110"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a99801b5bd34ede4cf3fc688c5919368fea4e4814a4664359503e6015b280aea"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1317,22 +1322,22 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.20.0"
+version = "3.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8a64e3985349f2441a1a9ef0b853f869006c3855f2cda6862a94d26ebb9d6a1"
+checksum = "2d31c77bdf42a745371d260a26ca7163f1e0924b64afa0b688e61b5a9fa02f16"
 dependencies = [
  "fastrand",
  "getrandom",
  "once_cell",
- "rustix 1.0.7",
- "windows-sys 0.59.0",
+ "rustix 1.1.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "time"
-version = "0.3.41"
+version = "0.3.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a7619e19bc266e0f9c5e6686659d394bc57973859340060a69221e57dbc0c40"
+checksum = "91e7d9e3bb61134e77bde20dd4825b97c010155709965fedf0f49bb138e52a9d"
 dependencies = [
  "deranged",
  "num-conv",
@@ -1343,38 +1348,37 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.4"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9e9a38711f559d9e3ce1cdb06dd7c5b8ea546bc90052da6d06bb76da74bb07c"
+checksum = "40868e7c1d2f0b8d73e4a8c7f0ff63af4f6d19be117e90bd73eb1d62cf831c6b"
 
 [[package]]
 name = "tokio"
-version = "1.45.0"
+version = "1.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2513ca694ef9ede0fb23fe71a4ee4107cb102b9dc1930f6d0fd77aae068ae165"
+checksum = "ff360e02eab121e0bc37a2d3b4d4dc622e6eda3a8e5253d5435ecf5bd4c68408"
 dependencies = [
- "backtrace",
  "bytes",
  "pin-project-lite",
 ]
 
 [[package]]
 name = "typenum"
-version = "1.18.0"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
+checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.18"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
 
 [[package]]
 name = "unicode-width"
-version = "0.1.14"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
 name = "unicode-xid"
@@ -1411,45 +1415,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
-name = "wasi"
-version = "0.14.2+wasi-0.2.4"
+name = "wasip2"
+version = "1.0.1+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
+checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
 dependencies = [
- "wit-bindgen-rt",
+ "wit-bindgen",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.100"
+version = "0.2.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
+checksum = "da95793dfc411fbbd93f5be7715b0578ec61fe87cb1a42b12eb625caa5c5ea60"
 dependencies = [
  "cfg-if",
  "once_cell",
  "rustversion",
  "wasm-bindgen-macro",
-]
-
-[[package]]
-name = "wasm-bindgen-backend"
-version = "0.2.100"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
-dependencies = [
- "bumpalo",
- "log",
- "proc-macro2",
- "quote",
- "syn",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.100"
+version = "0.2.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
+checksum = "04264334509e04a7bf8690f2384ef5265f05143a4bff3889ab7a3269adab59c2"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1457,35 +1448,34 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.100"
+version = "0.2.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
+checksum = "420bc339d9f322e562942d52e115d57e950d12d88983a14c79b86859ee6c7ebc"
 dependencies = [
+ "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
- "wasm-bindgen-backend",
+ "syn 2.0.110",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.100"
+version = "0.2.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+checksum = "76f218a38c84bcb33c25ec7059b07847d465ce0e0a76b995e134a45adcb6af76"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "which"
-version = "7.0.3"
+version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24d643ce3fd3e5b54854602a080f34fb10ab75e0b813ee32d00ca2b44fa74762"
+checksum = "d3fabb953106c3c8eea8306e4393700d7657561cb43122571b172bbfb7c7ba1d"
 dependencies = [
- "either",
  "env_home",
- "rustix 1.0.7",
+ "rustix 1.1.2",
  "winsafe",
 ]
 
@@ -1507,11 +1497,11 @@ checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
 name = "winapi-util"
-version = "0.1.9"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1522,9 +1512,9 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"
-version = "0.61.0"
+version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4763c1de310c86d75a878046489e2e5ba02c649d185f21c67d4cf8a56d098980"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
  "windows-implement",
  "windows-interface",
@@ -1535,57 +1525,48 @@ dependencies = [
 
 [[package]]
 name = "windows-implement"
-version = "0.60.0"
+version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.110",
 ]
 
 [[package]]
 name = "windows-interface"
-version = "0.59.1"
+version = "0.59.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.110",
 ]
 
 [[package]]
 name = "windows-link"
-version = "0.1.3"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-result"
-version = "0.3.2"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c64fd11a4fd95df68efcfee5f44a294fe71b8bc6a91993e2791938abcc712252"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
  "windows-link",
 ]
 
 [[package]]
 name = "windows-strings"
-version = "0.4.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2ba9642430ee452d5a7aa78d72907ebe8cfda358e8cb7918a2050581322f97"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
  "windows-link",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
-dependencies = [
- "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -1599,35 +1580,20 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
-dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
- "windows-targets 0.53.3",
+ "windows-targets 0.53.5",
 ]
 
 [[package]]
-name = "windows-targets"
-version = "0.48.5"
+name = "windows-sys"
+version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
- "windows_aarch64_gnullvm 0.48.5",
- "windows_aarch64_msvc 0.48.5",
- "windows_i686_gnu 0.48.5",
- "windows_i686_msvc 0.48.5",
- "windows_x86_64_gnu 0.48.5",
- "windows_x86_64_gnullvm 0.48.5",
- "windows_x86_64_msvc 0.48.5",
+ "windows-link",
 ]
 
 [[package]]
@@ -1648,26 +1614,20 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.53.3"
+version = "0.53.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5fe6031c4041849d7c496a8ded650796e7b6ecc19df1a431c1a363342e5dc91"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
 dependencies = [
  "windows-link",
- "windows_aarch64_gnullvm 0.53.0",
- "windows_aarch64_msvc 0.53.0",
- "windows_i686_gnu 0.53.0",
- "windows_i686_gnullvm 0.53.0",
- "windows_i686_msvc 0.53.0",
- "windows_x86_64_gnu 0.53.0",
- "windows_x86_64_gnullvm 0.53.0",
- "windows_x86_64_msvc 0.53.0",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -1677,15 +1637,9 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -1695,15 +1649,9 @@ checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1713,9 +1661,9 @@ checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
 
 [[package]]
 name = "windows_i686_gnullvm"
@@ -1725,15 +1673,9 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_gnullvm"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -1743,15 +1685,9 @@ checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -1761,15 +1697,9 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -1779,15 +1709,9 @@ checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -1797,9 +1721,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winsafe"
@@ -1808,13 +1732,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
 
 [[package]]
-name = "wit-bindgen-rt"
-version = "0.39.0"
+name = "wit-bindgen"
+version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
-dependencies = [
- "bitflags 2.8.0",
-]
+checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
 
 [[package]]
 name = "xz2"
@@ -1826,26 +1747,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "zerocopy"
-version = "0.8.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1702d9583232ddb9174e01bb7c15a2ab8fb1bc6f227aa1233858c351a3ba0cb"
-dependencies = [
- "zerocopy-derive",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.8.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28a6e20d751156648aa063f3800b706ee209a32c0b4d9f24be3d980b01be55ef"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "zip"
 version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1853,13 +1754,28 @@ checksum = "12598812502ed0105f607f941c386f43d441e00148fce9dec3ca5ffb0bde9308"
 dependencies = [
  "arbitrary",
  "crc32fast",
- "deflate64",
  "flate2",
  "indexmap",
  "lzma-rs",
  "memchr",
- "time",
  "xz2",
+ "zopfli",
+]
+
+[[package]]
+name = "zip"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb2a05c7c36fde6c09b08576c9f7fb4cda705990f73b58fe011abf7dfb24168b"
+dependencies = [
+ "arbitrary",
+ "crc32fast",
+ "deflate64",
+ "flate2",
+ "indexmap",
+ "lzma-rust2",
+ "memchr",
+ "time",
  "zopfli",
 ]
 
@@ -1869,7 +1785,7 @@ version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f105becb0a5da773e655775dd05fee454ca1475bcc980ec9d940a02f42cee40"
 dependencies = [
- "zip",
+ "zip 3.0.0",
 ]
 
 [[package]]
@@ -1880,12 +1796,40 @@ checksum = "2f06ae92f42f5e5c42443fd094f245eb656abf56dd7cce9b8b263236565e00f2"
 
 [[package]]
 name = "zopfli"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edfc5ee405f504cd4984ecc6f14d02d55cfda60fa4b689434ef4102aae150cd7"
+checksum = "f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249"
 dependencies = [
  "bumpalo",
  "crc32fast",
  "log",
  "simd-adler32",
+]
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
 ]

--- a/userspace/ksud/Cargo.toml
+++ b/userspace/ksud/Cargo.toml
@@ -6,11 +6,11 @@ edition = "2024"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-notify = "6.1"
+notify = "8.2"
 anyhow = "1"
 clap = { version = "4", features = ["derive"] }
 const_format = "0.2"
-zip = { version = "3",  features = [
+zip = { version = "6",  features = [
     "deflate",
     "deflate64",
     "time",
@@ -38,7 +38,7 @@ rust-embed = { version = "8", features = [
     "debug-embed",
     "compression", # must clean build after updating binaries
 ] }
-which = "7"
+which = "8"
 getopts = "0.2"
 sha256 = "1"
 sha1 = "0.10"
@@ -48,14 +48,14 @@ regex-lite = "0.1"
 serde = { version = "1.0", features = ["derive"] }
 
 [target.'cfg(any(target_os = "android", target_os = "linux"))'.dependencies]
-rustix = { git = "https://github.com/Kernel-SU/rustix.git", branch = "main", features = [
+rustix = { git = "https://github.com/Kernel-SU/rustix.git", rev = "4a53fbc7cb7a07cabe87125cc21dbc27db316259", features = [
     "all-apis",
 ] }
 # some android specific dependencies which compiles under unix are also listed here for convenience of coding
 android-properties = { version = "0.2", features = ["bionic-deprecated"] }
 
 [target.'cfg(target_os = "android")'.dependencies]
-android_logger = { version = "0.14", default-features = false }
+android_logger = { version = "0.15", default-features = false }
 
 [profile.release]
 overflow-checks = false


### PR DESCRIPTION
```
Name                                              Project            Compat   Latest   Kind         Platform
----                                              -------            ------   ------   ----         --------
addr2line->gimli                                  0.31.1             Removed  Removed  Normal       ---
ahash->cfg-if                                     1.0.0              Removed  Removed  Normal       ---
ahash->once_cell                                  1.21.3             Removed  Removed  Normal       cfg(not(all(target_arch = "arm", target_os = "none")))
ahash->version_check                              0.9.5              Removed  Removed  Build        ---
ahash->zerocopy                                   0.8.25             Removed  Removed  Normal       ---
android_logger                                    0.14.1             ---      0.15.1   Normal       cfg(target_os = "android")
android_logger->env_filter                        0.1.3              0.1.4    0.1.4    Normal       ---
android_logger->log                               0.4.27             0.4.28   0.4.28   Normal       ---
android_system_properties->libc                   0.2.172            0.2.177  0.2.177  Normal       ---
anstream->anstyle                                 1.0.10             1.0.13   1.0.13   Normal       ---
anstream->anstyle-parse                           0.2.6              0.2.7    0.2.7    Normal       ---
anstream->anstyle-query                           1.1.2              1.1.5    1.1.5    Normal       ---
anstream->anstyle-wincon                          3.0.7              3.0.11   3.0.11   Normal       cfg(windows)
anstream->colorchoice                             1.0.3              1.0.4    1.0.4    Normal       ---
anstream->is_terminal_polyfill                    1.70.1             1.70.2   1.70.2   Normal       ---
anstyle-query->windows-sys                        0.59.0             0.61.2   0.61.2   Normal       cfg(windows)
anstyle-wincon->anstyle                           1.0.10             1.0.13   1.0.13   Normal       ---
anstyle-wincon->once_cell                         1.21.3             Removed  Removed  Normal       cfg(windows)
anstyle-wincon->windows-sys                       0.59.0             0.61.2   0.61.2   Normal       cfg(windows)
anyhow                                            1.0.98             1.0.100  1.0.100  Normal       ---
arbitrary->derive_arbitrary                       1.4.1              1.4.2    1.4.2    Normal       ---
async-trait->proc-macro2                          1.0.95             1.0.103  1.0.103  Normal       ---
async-trait->quote                                1.0.40             1.0.42   1.0.42   Normal       ---
async-trait->syn                                  2.0.101            2.0.110  2.0.110  Normal       ---
backtrace->addr2line                              0.24.2             Removed  Removed  Normal       cfg(not(all(windows, target_env = "msvc", not(target_vendor = "uwp"))))
backtrace->cfg-if                                 1.0.0              Removed  Removed  Normal       ---
backtrace->libc                                   0.2.172            Removed  Removed  Normal       cfg(not(all(windows, target_env = "msvc", not(target_vendor = "uwp"))))
backtrace->miniz_oxide                            0.8.8              Removed  Removed  Normal       cfg(not(all(windows, target_env = "msvc", not(target_vendor = "uwp"))))
backtrace->object                                 0.36.7             Removed  Removed  Normal       cfg(not(all(windows, target_env = "msvc", not(target_vendor = "uwp"))))
backtrace->rustc-demangle                         0.1.24             Removed  Removed  Normal       ---
backtrace->windows-targets                        0.52.6             Removed  Removed  Normal       cfg(any(windows, target_os = "cygwin"))
cc->shlex                                         1.3.0              ---      Removed  Normal       ---
chrono                                            0.4.41             0.4.42   0.4.42   Normal       ---
chrono->android-tzdata                            0.1.1              Removed  Removed  Normal       cfg(target_os = "android")
chrono->iana-time-zone                            0.1.63             0.1.64   0.1.64   Normal       cfg(unix)
chrono->js-sys                                    0.3.77             0.3.82   0.3.82   Normal       cfg(all(target_arch = "wasm32", not(any(target_os = "emscripten", target_os = "wasi"))))
chrono->wasm-bindgen                              0.2.100            0.2.105  0.2.105  Normal       cfg(all(target_arch = "wasm32", not(any(target_os = "emscripten", target_os = "wasi"))))
chrono->windows-link                              0.1.3              0.2.1    0.2.1    Normal       cfg(windows)
clap                                              4.5.38             4.5.51   4.5.51   Normal       ---
clap->clap_builder                                4.5.38             4.5.51   4.5.51   Normal       ---
clap->clap_derive                                 4.5.32             4.5.49   4.5.49   Normal       ---
clap_builder->anstream                            0.6.18             0.6.21   0.6.21   Normal       ---
clap_builder->anstyle                             1.0.10             1.0.13   1.0.13   Normal       ---
clap_builder->clap_lex                            0.7.4              0.7.6    0.7.6    Normal       ---
clap_derive->proc-macro2                          1.0.95             1.0.103  1.0.103  Normal       ---
clap_derive->quote                                1.0.40             1.0.42   1.0.42   Normal       ---
clap_derive->syn                                  2.0.101            2.0.110  2.0.110  Normal       ---
const_format                                      0.2.34             0.2.35   0.2.35   Normal       ---
const_format_proc_macros->proc-macro2             1.0.95             1.0.103  1.0.103  Normal       ---
const_format_proc_macros->quote                   1.0.40             1.0.42   1.0.42   Normal       ---
core2->memchr                                     2.7.4              2.7.6    2.7.6    Normal       ---
cpufeatures->libc                                 0.2.172            0.2.177  0.2.177  Normal       aarch64-linux-android
crc->crc-catalog                                  2.4.0              ---      Removed  Normal       ---
crc32fast->cfg-if                                 1.0.0              1.0.4    1.0.4    Normal       ---
crossbeam-channel->crossbeam-utils                0.8.21             ---      Removed  Normal       ---
crypto-common->typenum                            1.18.0             1.19.0   1.19.0   Normal       ---
deranged->powerfmt                                0.2.0              ---      Removed  Normal       ---
derive-new->proc-macro2                           1.0.95             1.0.103  1.0.103  Normal       ---
derive-new->quote                                 1.0.40             1.0.42   1.0.42   Normal       ---
derive-new->syn                                   2.0.101            2.0.110  2.0.110  Normal       ---
derive_arbitrary->proc-macro2                     1.0.95             1.0.103  1.0.103  Normal       ---
derive_arbitrary->quote                           1.0.40             1.0.42   1.0.42   Normal       ---
derive_arbitrary->syn                             2.0.101            2.0.110  2.0.110  Normal       ---
digest->crypto-common                             0.1.6              0.1.7    0.1.7    Normal       ---
encoding_rs->cfg-if                               1.0.0              1.0.4    1.0.4    Normal       ---
env_filter->log                                   0.4.27             0.4.28   0.4.28   Normal       ---
env_logger->env_filter                            0.1.3              0.1.4    0.1.4    Normal       ---
env_logger->log                                   0.4.27             0.4.28   0.4.28   Normal       ---
errno->libc                                       0.2.172            0.2.177  0.2.177  Normal       cfg(target_os = "hermit")
errno->windows-sys                                0.59.0             0.61.2   0.61.2   Normal       cfg(windows)
errno-dragonfly->cc                               1.2.22             1.2.46   1.2.46   Build        ---
errno-dragonfly->libc                             0.2.172            0.2.177  0.2.177  Normal       ---
extattr->libc                                     0.2.172            0.2.177  0.2.177  Normal       ---
filetime->cfg-if                                  1.0.0              1.0.4    Removed  Normal       ---
filetime->libc                                    0.2.172            0.2.177  Removed  Normal       cfg(unix)
filetime->libredox                                0.1.9              0.1.10   Removed  Normal       cfg(target_os = "redox")
filetime->windows-sys                             0.60.2             ---      Removed  Normal       cfg(windows)
flate2->crc32fast                                 1.4.2              1.5.0    1.5.0    Normal       ---
flate2->miniz_oxide                               0.8.8              0.8.9    0.8.9    Normal       ---
fsevent-sys->libc                                 0.2.172            0.2.177  0.2.177  Normal       ---
generic-array->typenum                            1.18.0             1.19.0   1.19.0   Normal       ---
getopts                                           0.2.21             0.2.24   0.2.24   Normal       ---
getopts->unicode-width                            0.1.14             0.2.2    0.2.2    Normal       ---
getrandom->cfg-if                                 1.0.0              1.0.4    1.0.4    Normal       ---
getrandom->libc                                   0.2.172            0.2.177  0.2.177  Normal       cfg(all(any(target_os = "linux", target_os = "android"), not(any(all(target_os = "linux", target_env = ""), getrandom_backend = "custom", getrandom_backend = "linux_raw", getrandom_backend = "rdrand", getrandom_backend = "rndr"))))
getrandom->r-efi                                  5.2.0              5.3.0    5.3.0    Normal       cfg(all(target_os = "uefi", getrandom_backend = "efi_rng"))
getrandom->wasi                                   0.14.2+wasi-0.2.4  Removed  Removed  Normal       cfg(all(target_arch = "wasm32", target_os = "wasi", target_env = "p2"))
hashbrown->ahash                                  0.8.12             Removed  Removed  Normal       ---
iana-time-zone->js-sys                            0.3.77             0.3.82   0.3.82   Normal       cfg(all(target_arch = "wasm32", target_os = "unknown"))
iana-time-zone->log                               0.4.27             0.4.28   0.4.28   Normal       cfg(all(target_arch = "wasm32", target_os = "unknown"))
iana-time-zone->wasm-bindgen                      0.2.100            0.2.105  0.2.105  Normal       cfg(all(target_arch = "wasm32", target_os = "unknown"))
iana-time-zone->windows-core                      0.61.0             0.62.2   0.62.2   Normal       cfg(target_os = "windows")
iana-time-zone-haiku->cc                          1.2.22             1.2.46   1.2.46   Build        ---
include-flate->include-flate-codegen              0.2.0              0.3.1    0.3.1    Normal       ---
include-flate->lazy_static                        1.5.0              Removed  Removed  Normal       ---
include-flate->libflate                           2.1.0              2.2.1    2.2.1    Normal       ---
include-flate-codegen->libflate                   2.1.0              2.2.1    2.2.1    Normal       ---
include-flate-codegen->proc-macro2                1.0.95             1.0.103  1.0.103  Normal       ---
include-flate-codegen->quote                      1.0.40             1.0.42   1.0.42   Normal       ---
include-flate-codegen->syn                        2.0.101            2.0.110  2.0.110  Normal       ---
indexmap->hashbrown                               0.15.2             0.16.0   0.16.0   Normal       ---
inotify->bitflags                                 1.3.2              ---      2.10.0   Normal       ---
inotify->libc                                     0.2.172            0.2.177  0.2.177  Normal       ---
inotify-sys->libc                                 0.2.172            0.2.177  0.2.177  Normal       ---
is_executable                                     1.0.4              1.0.5    1.0.5    Normal       ---
is_executable->winapi                             0.3.9              Removed  Removed  Normal       cfg(target_os = "windows")
java-properties->regex-lite                       0.1.6              0.1.8    0.1.8    Normal       ---
js-sys->wasm-bindgen                              0.2.100            0.2.105  0.2.105  Normal       ---
jwalk->rayon                                      1.10.0             1.11.0   1.11.0   Normal       ---
kqueue->libc                                      0.2.172            0.2.177  0.2.177  Normal       ---
kqueue-sys->libc                                  0.2.172            0.2.177  0.2.177  Normal       ---
libc                                              0.2.172            0.2.177  0.2.177  Normal       ---
libflate->crc32fast                               1.4.2              1.5.0    1.5.0    Normal       ---
libflate->dary_heap                               0.3.7              0.3.8    0.3.8    Normal       ---
libflate->libflate_lz77                           2.1.0              2.2.0    2.2.0    Normal       ---
libflate_lz77->hashbrown                          0.14.5             0.16.0   0.16.0   Normal       ---
libredox->bitflags                                2.8.0              2.10.0   Removed  Normal       ---
libredox->libc                                    0.2.172            0.2.177  Removed  Normal       ---
libredox->redox_syscall                           0.5.17             0.5.18   Removed  Normal       ---
log                                               0.4.27             0.4.28   0.4.28   Normal       ---
lzma-rs->byteorder                                1.5.0              ---      Removed  Normal       ---
lzma-rs->crc                                      3.3.0              ---      Removed  Normal       ---
lzma-sys->cc                                      1.2.22             1.2.46   1.2.46   Build        ---
lzma-sys->cc                                      1.2.22             1.2.46   Removed  Build        ---
lzma-sys->libc                                    0.2.172            0.2.177  0.2.177  Normal       ---
lzma-sys->libc                                    0.2.172            0.2.177  Removed  Normal       ---
lzma-sys->pkg-config                              0.3.32             ---      Removed  Build        ---
miniz_oxide->adler2                               2.0.0              2.0.1    2.0.1    Normal       ---
miniz_oxide->adler2                               2.0.0              Removed  Removed  Normal       ---
mio->libc                                         0.2.172            0.2.177  0.2.177  Normal       cfg(target_os = "wasi")
mio->log                                          0.4.27             0.4.28   0.4.28   Normal       ---
mio->windows-sys                                  0.48.0             ---      0.61.2   Normal       cfg(windows)
nom->memchr                                       2.7.4              2.7.6    2.7.6    Normal       ---
notify                                            6.1.1              ---      8.2.0    Normal       ---
notify->bitflags                                  2.8.0              2.10.0   2.10.0   Normal       cfg(target_os = "macos")
notify->crossbeam-channel                         0.5.15             ---      Removed  Normal       ---
notify->filetime                                  0.2.26             ---      Removed  Normal       ---
notify->inotify                                   0.9.6              ---      0.11.0   Normal       cfg(any(target_os = "linux", target_os = "android"))
notify->libc                                      0.2.172            0.2.177  0.2.177  Normal       ---
notify->log                                       0.4.27             0.4.28   0.4.28   Normal       ---
notify->mio                                       0.8.11             ---      1.1.0    Normal       cfg(any(target_os = "freebsd", target_os = "openbsd", target_os = "netbsd", target_os = "dragonflybsd"))
notify->windows-sys                               0.48.0             ---      0.60.2   Normal       cfg(windows)
num-traits->autocfg                               1.4.0              1.5.0    1.5.0    Build        ---
object->memchr                                    2.7.4              Removed  Removed  Normal       ---
proc-macro2->unicode-ident                        1.0.18             1.0.22   1.0.22   Normal       ---
proc-macro2->unicode-ident                        1.0.18             1.0.22   Removed  Normal       ---
proc-macro2->unicode-ident                        1.0.18             Removed  Removed  Normal       ---
quote->proc-macro2                                1.0.95             1.0.103  1.0.103  Normal       ---
quote->proc-macro2                                1.0.95             1.0.103  Removed  Normal       ---
quote->proc-macro2                                1.0.95             Removed  Removed  Normal       ---
rayon->rayon-core                                 1.12.1             1.13.0   1.13.0   Normal       ---
redox_syscall->bitflags                           2.8.0              2.10.0   Removed  Normal       ---
regex-lite                                        0.1.6              0.1.8    0.1.8    Normal       ---
rust-embed                                        8.7.2              8.9.0    8.9.0    Normal       ---
rust-embed->include-flate                         0.3.0              0.3.1    0.3.1    Normal       ---
rust-embed->rust-embed-impl                       8.7.2              8.9.0    8.9.0    Normal       ---
rust-embed->rust-embed-utils                      8.7.2              8.9.0    8.9.0    Normal       ---
rust-embed-impl->proc-macro2                      1.0.95             1.0.103  1.0.103  Normal       ---
rust-embed-impl->quote                            1.0.40             1.0.42   1.0.42   Normal       ---
rust-embed-impl->rust-embed-utils                 8.7.2              8.9.0    8.9.0    Normal       ---
rust-embed-impl->syn                              2.0.101            2.0.110  2.0.110  Normal       ---
rustix                                            0.38.34            1.1.2    1.1.2    Normal       cfg(any(target_os = "android", target_os = "linux"))
rustix->bitflags                                  2.8.0              2.10.0   2.10.0   Normal       ---
rustix->errno                                     0.3.10             0.3.14   0.3.14   Development  ---
rustix->itoa                                      1.0.15             Removed  Removed  Normal       ---
rustix->libc                                      0.2.172            0.2.177  0.2.177  Development  ---
rustix->linux-raw-sys                             0.4.15             0.11.0   0.11.0   Normal       cfg(all(any(target_os = "android", target_os = "linux"), any(rustix_use_libc, miri, not(all(target_os = "linux", target_endian = "little", any(target_arch = "arm", all(target_arch = "aarch64", target_pointer_width = "64"), target_arch = "riscv64", all(rustix_use_experimental_asm, target_arch = "powerpc64"), all(rustix_use_experimental_asm, target_arch = "mips"), all(rustix_use_experimental_asm, target_arch = "mips32r6"), all(rustix_use_experimental_asm, target_arch = "mips64"), all(rustix_use_experimental_asm, target_arch = "mips64r6"), target_arch = "x86", all(target_arch = "x86_64", target_pointer_width = "64")))))))
rustix->linux-raw-sys                             0.9.4              0.11.0   0.11.0   Normal       cfg(all(any(target_os = "android", target_os = "linux"), any(rustix_use_libc, miri, not(all(target_os = "linux", any(target_endian = "little", any(target_arch = "s390x", target_arch = "powerpc")), any(target_arch = "arm", all(target_arch = "aarch64", target_pointer_width = "64"), target_arch = "riscv64", all(rustix_use_experimental_asm, target_arch = "powerpc"), all(rustix_use_experimental_asm, target_arch = "powerpc64"), all(rustix_use_experimental_asm, target_arch = "s390x"), all(rustix_use_experimental_asm, target_arch = "mips"), all(rustix_use_experimental_asm, target_arch = "mips32r6"), all(rustix_use_experimental_asm, target_arch = "mips64"), all(rustix_use_experimental_asm, target_arch = "mips64r6"), target_arch = "x86", all(target_arch = "x86_64", target_pointer_width = "64")))))))
rustix->once_cell                                 1.21.3             Removed  Removed  Normal       cfg(any(target_os = "android", target_os = "linux"))
rustix->windows-sys                               0.52.0             0.61.2   0.61.2   Normal       cfg(windows)
rustix->windows-sys                               0.59.0             0.61.2   0.61.2   Normal       cfg(windows)
same-file->winapi-util                            0.1.9              0.1.11   0.1.11   Normal       cfg(windows)
serde                                             1.0.219            1.0.228  1.0.228  Normal       ---
serde->serde_derive                               1.0.219            1.0.228  1.0.228  Normal       ---
serde->serde_derive                               1.0.219            1.0.228  Removed  Normal       ---
serde_derive->proc-macro2                         1.0.95             1.0.103  1.0.103  Normal       ---
serde_derive->proc-macro2                         1.0.95             1.0.103  Removed  Normal       ---
serde_derive->quote                               1.0.40             1.0.42   1.0.42   Normal       ---
serde_derive->quote                               1.0.40             1.0.42   Removed  Normal       ---
serde_derive->syn                                 2.0.101            2.0.110  2.0.110  Normal       ---
serde_derive->syn                                 2.0.101            2.0.110  Removed  Normal       ---
serde_json                                        1.0.140            1.0.145  1.0.145  Normal       ---
serde_json->memchr                                2.7.4              2.7.6    2.7.6    Normal       ---
serde_json->serde                                 1.0.219            1.0.228  1.0.228  Normal       ---
sha1->cfg-if                                      1.0.0              1.0.4    1.0.4    Normal       ---
sha2->cfg-if                                      1.0.0              1.0.4    1.0.4    Normal       ---
sha256->async-trait                               0.1.88             0.1.89   0.1.89   Normal       ---
sha256->bytes                                     1.10.1             1.11.0   1.11.0   Normal       ---
sha256->tokio                                     1.45.0             1.48.0   1.48.0   Normal       ---
syn->proc-macro2                                  1.0.95             1.0.103  1.0.103  Normal       ---
syn->proc-macro2                                  1.0.95             1.0.103  Removed  Normal       ---
syn->proc-macro2                                  1.0.95             Removed  Removed  Normal       ---
syn->quote                                        1.0.40             1.0.42   1.0.42   Normal       ---
syn->quote                                        1.0.40             1.0.42   Removed  Normal       ---
syn->quote                                        1.0.40             Removed  Removed  Normal       ---
syn->unicode-ident                                1.0.18             1.0.22   1.0.22   Normal       ---
syn->unicode-ident                                1.0.18             1.0.22   Removed  Normal       ---
syn->unicode-ident                                1.0.18             Removed  Removed  Normal       ---
tempfile                                          3.20.0             3.23.0   3.23.0   Normal       ---
tempfile->getrandom                               0.3.3              0.3.4    0.3.4    Normal       cfg(any(unix, windows, target_os = "wasi"))
tempfile->rustix                                  1.0.7              1.1.2    1.1.2    Normal       cfg(any(unix, target_os = "wasi"))
tempfile->windows-sys                             0.59.0             0.61.2   0.61.2   Normal       cfg(windows)
time->deranged                                    0.4.0              0.5.5    0.5.5    Normal       ---
time->deranged                                    0.4.0              0.5.5    Removed  Normal       ---
time->num-conv                                    0.1.0              ---      Removed  Normal       ---
time->powerfmt                                    0.2.0              ---      Removed  Normal       ---
time->serde                                       1.0.219            1.0.228  1.0.228  Normal       ---
time->serde                                       1.0.219            1.0.228  Removed  Normal       ---
time->time-core                                   0.1.4              0.1.6    0.1.6    Normal       ---
time->time-core                                   0.1.4              0.1.6    Removed  Normal       ---
tokio->backtrace                                  0.3.75             Removed  Removed  Normal       cfg(tokio_taskdump)
tokio->bytes                                      1.10.1             1.11.0   1.11.0   Normal       ---
walkdir->winapi-util                              0.1.9              0.1.11   0.1.11   Normal       cfg(windows)
wasi->wit-bindgen-rt                              0.39.0             Removed  Removed  Normal       ---
wasm-bindgen->cfg-if                              1.0.0              1.0.4    1.0.4    Normal       ---
wasm-bindgen->rustversion                         1.0.20             1.0.22   1.0.22   Normal       ---
wasm-bindgen->wasm-bindgen-macro                  0.2.100            0.2.105  0.2.105  Normal       ---
wasm-bindgen-backend->bumpalo                     3.17.0             Removed  Removed  Normal       ---
wasm-bindgen-backend->log                         0.4.27             Removed  Removed  Normal       ---
wasm-bindgen-backend->proc-macro2                 1.0.95             Removed  Removed  Normal       ---
wasm-bindgen-backend->quote                       1.0.40             Removed  Removed  Normal       ---
wasm-bindgen-backend->syn                         2.0.101            Removed  Removed  Normal       ---
wasm-bindgen-backend->wasm-bindgen-shared         0.2.100            Removed  Removed  Normal       ---
wasm-bindgen-macro->quote                         1.0.40             1.0.42   1.0.42   Normal       ---
wasm-bindgen-macro->wasm-bindgen-macro-support    0.2.100            0.2.105  0.2.105  Normal       ---
wasm-bindgen-macro-support->proc-macro2           1.0.95             1.0.103  1.0.103  Normal       ---
wasm-bindgen-macro-support->quote                 1.0.40             1.0.42   1.0.42   Normal       ---
wasm-bindgen-macro-support->syn                   2.0.101            2.0.110  2.0.110  Normal       ---
wasm-bindgen-macro-support->wasm-bindgen-backend  0.2.100            Removed  Removed  Normal       ---
wasm-bindgen-macro-support->wasm-bindgen-shared   0.2.100            0.2.105  0.2.105  Normal       ---
wasm-bindgen-shared->unicode-ident                1.0.18             1.0.22   1.0.22   Normal       ---
wasm-bindgen-shared->unicode-ident                1.0.18             Removed  Removed  Normal       ---
which                                             7.0.3              ---      8.0.0    Normal       ---
which->either                                     1.15.0             ---      Removed  Normal       ---
which->rustix                                     1.0.7              1.1.2    1.1.2    Normal       cfg(any(unix, target_os = "wasi", target_os = "redox"))
winapi->winapi-i686-pc-windows-gnu                0.4.0              Removed  Removed  Normal       i686-pc-windows-gnu
winapi->winapi-x86_64-pc-windows-gnu              0.4.0              Removed  Removed  Normal       x86_64-pc-windows-gnu
winapi-util->windows-sys                          0.59.0             0.61.2   0.61.2   Normal       cfg(windows)
windows-core->windows-implement                   0.60.0             0.60.2   0.60.2   Normal       ---
windows-core->windows-interface                   0.59.1             0.59.3   0.59.3   Normal       ---
windows-core->windows-link                        0.1.3              0.2.1    0.2.1    Normal       ---
windows-core->windows-result                      0.3.2              0.4.1    0.4.1    Normal       ---
windows-core->windows-strings                     0.4.0              0.5.1    0.5.1    Normal       ---
windows-implement->proc-macro2                    1.0.95             1.0.103  1.0.103  Normal       ---
windows-implement->quote                          1.0.40             1.0.42   1.0.42   Normal       ---
windows-implement->syn                            2.0.101            2.0.110  2.0.110  Normal       ---
windows-interface->proc-macro2                    1.0.95             1.0.103  1.0.103  Normal       ---
windows-interface->quote                          1.0.40             1.0.42   1.0.42   Normal       ---
windows-interface->syn                            2.0.101            2.0.110  2.0.110  Normal       ---
windows-result->windows-link                      0.1.3              0.2.1    0.2.1    Normal       ---
windows-strings->windows-link                     0.1.3              0.2.1    0.2.1    Normal       ---
windows-sys->windows-targets                      0.48.5             ---      0.53.5   Normal       ---
windows-sys->windows-targets                      0.48.5             ---      Removed  Normal       ---
windows-sys->windows-targets                      0.52.6             Removed  Removed  Normal       ---
windows-sys->windows-targets                      0.53.3             0.53.5   Removed  Normal       ---
windows-targets->windows-link                     0.1.3              0.2.1    Removed  Normal       cfg(windows_raw_dylib)
windows-targets->windows_aarch64_gnullvm          0.48.5             ---      0.53.1   Normal       aarch64-pc-windows-gnullvm
windows-targets->windows_aarch64_gnullvm          0.48.5             ---      Removed  Normal       aarch64-pc-windows-gnullvm
windows-targets->windows_aarch64_gnullvm          0.52.6             Removed  Removed  Normal       aarch64-pc-windows-gnullvm
windows-targets->windows_aarch64_gnullvm          0.53.0             0.53.1   Removed  Normal       aarch64-pc-windows-gnullvm
windows-targets->windows_aarch64_msvc             0.48.5             ---      0.53.1   Normal       cfg(all(target_arch = "aarch64", target_env = "msvc", not(windows_raw_dylib)))
windows-targets->windows_aarch64_msvc             0.48.5             ---      Removed  Normal       cfg(all(target_arch = "aarch64", target_env = "msvc", not(windows_raw_dylib)))
windows-targets->windows_aarch64_msvc             0.52.6             Removed  Removed  Normal       cfg(all(target_arch = "aarch64", target_env = "msvc", not(windows_raw_dylib)))
windows-targets->windows_aarch64_msvc             0.53.0             0.53.1   Removed  Normal       cfg(all(target_arch = "aarch64", target_env = "msvc", not(windows_raw_dylib)))
windows-targets->windows_i686_gnu                 0.48.5             ---      0.53.1   Normal       cfg(all(target_arch = "x86", target_env = "gnu", not(windows_raw_dylib)))
windows-targets->windows_i686_gnu                 0.48.5             ---      Removed  Normal       cfg(all(target_arch = "x86", target_env = "gnu", not(windows_raw_dylib)))
windows-targets->windows_i686_gnu                 0.52.6             Removed  Removed  Normal       cfg(all(target_arch = "x86", target_env = "gnu", not(target_abi = "llvm"), not(windows_raw_dylib)))
windows-targets->windows_i686_gnu                 0.53.0             0.53.1   Removed  Normal       cfg(all(target_arch = "x86", target_env = "gnu", not(target_abi = "llvm"), not(windows_raw_dylib)))
windows-targets->windows_i686_gnullvm             0.52.6             Removed  Removed  Normal       i686-pc-windows-gnullvm
windows-targets->windows_i686_gnullvm             0.53.0             0.53.1   Removed  Normal       i686-pc-windows-gnullvm
windows-targets->windows_i686_msvc                0.48.5             ---      0.53.1   Normal       cfg(all(target_arch = "x86", target_env = "msvc", not(windows_raw_dylib)))
windows-targets->windows_i686_msvc                0.48.5             ---      Removed  Normal       cfg(all(target_arch = "x86", target_env = "msvc", not(windows_raw_dylib)))
windows-targets->windows_i686_msvc                0.52.6             Removed  Removed  Normal       cfg(all(target_arch = "x86", target_env = "msvc", not(windows_raw_dylib)))
windows-targets->windows_i686_msvc                0.53.0             0.53.1   Removed  Normal       cfg(all(target_arch = "x86", target_env = "msvc", not(windows_raw_dylib)))
windows-targets->windows_x86_64_gnu               0.48.5             ---      0.53.1   Normal       cfg(all(target_arch = "x86_64", target_env = "gnu", not(target_abi = "llvm"), not(windows_raw_dylib)))
windows-targets->windows_x86_64_gnu               0.48.5             ---      Removed  Normal       cfg(all(target_arch = "x86_64", target_env = "gnu", not(target_abi = "llvm"), not(windows_raw_dylib)))
windows-targets->windows_x86_64_gnu               0.52.6             Removed  Removed  Normal       cfg(all(target_arch = "x86_64", target_env = "gnu", not(target_abi = "llvm"), not(windows_raw_dylib)))
windows-targets->windows_x86_64_gnu               0.53.0             0.53.1   Removed  Normal       cfg(all(target_arch = "x86_64", target_env = "gnu", not(target_abi = "llvm"), not(windows_raw_dylib)))
windows-targets->windows_x86_64_gnullvm           0.48.5             ---      0.53.1   Normal       x86_64-pc-windows-gnullvm
windows-targets->windows_x86_64_gnullvm           0.48.5             ---      Removed  Normal       x86_64-pc-windows-gnullvm
windows-targets->windows_x86_64_gnullvm           0.52.6             Removed  Removed  Normal       x86_64-pc-windows-gnullvm
windows-targets->windows_x86_64_gnullvm           0.53.0             0.53.1   Removed  Normal       x86_64-pc-windows-gnullvm
windows-targets->windows_x86_64_msvc              0.48.5             ---      0.53.1   Normal       cfg(all(target_arch = "x86_64", target_env = "msvc", not(windows_raw_dylib)))
windows-targets->windows_x86_64_msvc              0.48.5             ---      Removed  Normal       cfg(all(target_arch = "x86_64", target_env = "msvc", not(windows_raw_dylib)))
windows-targets->windows_x86_64_msvc              0.52.6             Removed  Removed  Normal       cfg(all(any(target_arch = "x86_64", target_arch = "arm64ec"), target_env = "msvc", not(windows_raw_dylib)))
windows-targets->windows_x86_64_msvc              0.53.0             0.53.1   Removed  Normal       cfg(all(any(target_arch = "x86_64", target_arch = "arm64ec"), target_env = "msvc", not(windows_raw_dylib)))
wit-bindgen-rt->bitflags                          2.8.0              Removed  Removed  Normal       ---
xz2->lzma-sys                                     0.1.20             ---      Removed  Normal       ---
zerocopy->zerocopy-derive                         0.8.25             Removed  Removed  Normal       ---
zerocopy-derive->proc-macro2                      1.0.95             Removed  Removed  Normal       ---
zerocopy-derive->quote                            1.0.40             Removed  Removed  Normal       ---
zerocopy-derive->syn                              2.0.101            Removed  Removed  Normal       ---
zip                                               3.0.0              ---      6.0.0    Normal       ---
zip->arbitrary                                    1.4.1              1.4.2    1.4.2    Normal       cfg(fuzzing)
zip->crc32fast                                    1.4.2              1.5.0    1.5.0    Normal       ---
zip->deflate64                                    0.1.9              0.1.10   0.1.10   Normal       ---
zip->deflate64                                    0.1.9              0.1.10   Removed  Normal       ---
zip->flate2                                       1.1.1              1.1.5    1.1.5    Normal       ---
zip->indexmap                                     2.9.0              2.12.0   2.12.0   Normal       ---
zip->lzma-rs                                      0.3.0              ---      Removed  Normal       ---
zip->memchr                                       2.7.4              2.7.6    2.7.6    Normal       ---
zip->time                                         0.3.41             0.3.44   0.3.44   Normal       ---
zip->time                                         0.3.41             0.3.44   Removed  Normal       ---
zip->xz2                                          0.1.7              ---      Removed  Normal       ---
zip->zopfli                                       0.8.2              0.8.3    0.8.3    Normal       ---
zopfli->bumpalo                                   3.17.0             3.19.0   3.19.0   Normal       ---
zopfli->crc32fast                                 1.4.2              1.5.0    1.5.0    Normal       ---
zopfli->log                                       0.4.27             0.4.28   0.4.28   Normal       ---
```