### PR TITLE
kernel: added missing endif in the if-else block

### DIFF
--- a/kernel/file_wrapper.c
+++ b/kernel/file_wrapper.c
@@ -286,6 +286,7 @@ static int ksu_wrapper_clone_file_range(struct file *file_in, loff_t pos_in,
 	}
 	return -EINVAL;
 }
+#endif
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 19, 0)
 static int ksu_wrapper_dedupe_file_range(struct file *src_file, loff_t loff,
 				struct file *dst_file, loff_t dst_loff, u64 len) {


### PR DESCRIPTION
/home/runner/work/GKI_SukiSU_SUSFS/GKI_SukiSU_SUSFS/android12-5.10-X/common/drivers/kernelsu/file_wrapper.c:257:2: error: unterminated conditional directive
  #if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 20, 0)
   ^
  1 error generated.
  make[3]: *** [/home/runner/work/GKI_SukiSU_SUSFS/GKI_SukiSU_SUSFS/android12-5.10-X/common/scripts/Makefile.build:273: drivers/kernelsu/file_wrapper.o] Error 1