### PR TITLE
Remove wrong compatibility code from susfs-main

### DIFF
--- a/kernel/app_profile.c
+++ b/kernel/app_profile.c
@@ -82,9 +82,8 @@ void disable_seccomp(void)
 #ifdef CONFIG_SECCOMP
 	current->seccomp.mode = 0;
 	current->seccomp.filter = NULL;
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 8, 0)
 	atomic_set(&current->seccomp.filter_count, 0);
-#endif
+#else
 #endif
 }
 

--- a/kernel/file_wrapper.c
+++ b/kernel/file_wrapper.c
@@ -254,7 +254,7 @@ static ssize_t ksu_wrapper_copy_file_range(struct file *f1, loff_t off1, struct 
 	return -EINVAL;
 }
 
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 20, 0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 19, 0)
 static loff_t ksu_wrapper_remap_file_range(struct file *file_in, loff_t pos_in,
 				struct file *file_out, loff_t pos_out,
 				loff_t len, unsigned int remap_flags) {
@@ -286,19 +286,7 @@ static int ksu_wrapper_clone_file_range(struct file *file_in, loff_t pos_in,
 	}
 	return -EINVAL;
 }
-#endif
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 19, 0)
-static int ksu_wrapper_dedupe_file_range(struct file *src_file, loff_t loff,
-				struct file *dst_file, loff_t dst_loff, u64 len) {
-	// TODO: determine which file to use
-	struct ksu_file_wrapper* data = src_file->private_data;
-	struct file* orig = data->orig;
-	if (orig->f_op->dedupe_file_range) {
-		return orig->f_op->dedupe_file_range(orig, loff, dst_file, dst_loff, len);
-	}
-	return -EINVAL;
-}
-#else
+
 static ssize_t ksu_wrapper_dedupe_file_range(struct file *src_file, u64 loff,
 				u64 len, struct file *dst_file, u64 dst_loff) {
 	// TODO: determine which file to use
@@ -365,7 +353,7 @@ struct ksu_file_wrapper* ksu_create_file_wrapper(struct file* fp) {
 	p->ops.fallocate = fp->f_op->fallocate ? ksu_wrapper_fallocate : NULL;
 	p->ops.show_fdinfo = fp->f_op->show_fdinfo ? ksu_wrapper_show_fdinfo : NULL;
 	p->ops.copy_file_range = fp->f_op->copy_file_range ? ksu_wrapper_copy_file_range : NULL;
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 20, 0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 19, 0)
 	p->ops.remap_file_range = fp->f_op->remap_file_range ? ksu_wrapper_remap_file_range : NULL;
 	p->ops.fadvise = fp->f_op->fadvise ? ksu_wrapper_fadvise : NULL;
 #else

--- a/kernel/selinux/selinux.c
+++ b/kernel/selinux/selinux.c
@@ -106,11 +106,7 @@ bool is_task_ksu_domain(const struct cred* cred)
     if (!cred) {
         return false;
     }
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,1,0)
     const struct task_security_struct *tsec = selinux_cred(cred);
-#else
-    const struct task_security_struct *tsec = cred->security;
-#endif
     if (!tsec) {
         return false;
     }
@@ -134,11 +130,7 @@ bool is_context(const struct cred* cred, const char* context)
     if (!cred) {
         return false;
     }
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,1,0)
-    const struct task_security_struct *tsec = selinux_cred(cred);
-#else
-    const struct task_security_struct *tsec = cred->security;
-#endif
+    const struct task_security_struct * tsec = selinux_cred(cred);
     if (!tsec) {
         return false;
     }

--- a/kernel/sucompat.c
+++ b/kernel/sucompat.c
@@ -351,12 +351,7 @@ int ksu_handle_devpts(struct inode *inode)
             return 0;
 
     if (ksu_file_sid) {
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 1, 0) || defined(KSU_OPTIONAL_SELINUX_INODE)
-    struct inode_security_struct *sec = selinux_inode(inode);
-#else
-    struct inode_security_struct *sec =
-        (struct inode_security_struct *)inode->i_security;
-#endif
+        struct inode_security_struct *sec = selinux_inode(inode);
         if (sec) {
             sec->sid = ksu_file_sid;
         }

--- a/kernel/supercalls.c
+++ b/kernel/supercalls.c
@@ -466,12 +466,7 @@ static int do_get_wrapper_fd(void __user *arg) {
     struct inode* wrapper_inode = file_inode(pf);
     // copy original inode mode
     wrapper_inode->i_mode = file_inode(f)->i_mode;
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 1, 0) || defined(KSU_OPTIONAL_SELINUX_INODE)
     struct inode_security_struct *sec = selinux_inode(wrapper_inode);
-#else
-    struct inode_security_struct *sec =
-        (struct inode_security_struct *)wrapper_inode->i_security;
-#endif
     if (sec) {
         sec->sid = ksu_file_sid;
     }


### PR DESCRIPTION
Nongki compatibility code should be committed to nongki branch, rather than susfs-main branch.