### PR TITLE
kernel: Manual hook shouldn't be enabled when susfs is enabled

### DIFF
--- a/kernel/Kconfig
+++ b/kernel/Kconfig
@@ -50,7 +50,7 @@ config KPM
 
 config KSU_MANUAL_HOOK
 	bool "Hook KernelSU manually"
-	depends on KSU != m
+	depends on KSU != m && !KSU_SUSFS
 	help
 	  If enabled, Hook required KernelSU syscalls with manually-patched function.
 


### PR DESCRIPTION
susfs already includes hook since v2.0.0, so manual hook shouldn't be enabled when susfs is enabled