### PR TITLE
fix build

### DIFF
--- a/kernel/kernel_umount.c
+++ b/kernel/kernel_umount.c
@@ -125,8 +125,6 @@ static void umount_tw_func(struct callback_head *cb)
 	}
 	up_read(&mount_list_lock);
 
-	ksu_umount_manager_execute_all(saved);
-
 	revert_creds(saved);
 
 	kfree(tw);


### PR DESCRIPTION
ld.lld: error: undefined symbol: ksu_umount_manager_execute_all
>>> referenced by kernel_umount.c:128 (/home/runner/work/op_ace6_kbuild/op_ace6_kbuild/kernel_workspace/kernel_platform/common/out/../drivers/kernelsu/kernel_umount.c:128)
>>>               drivers/kernelsu/kernel_umount.o:(umount_tw_func) in archive vmlinux.a