### PR TITLE
kernel: revert add KSU_UMOUNT_LIST

### DIFF
--- a/kernel/supercalls.c
+++ b/kernel/supercalls.c
@@ -656,51 +656,6 @@ static int add_try_umount(void __user *arg)
 			
 			return 0;
 		}
-
-		case KSU_UMOUNT_LIST: {
-            char *output_buf;
-            size_t output_size = cmd.buf_size ? cmd.buf_size : 4096;
-            size_t offset = 0;
-            int ret = 0;
-
-            if (!cmd.arg || !output_size)
-                return -EINVAL;
-
-            output_buf = kzalloc(output_size, GFP_KERNEL);
-            if (!output_buf)
-                return -ENOMEM;
-
-            // Write header
-            offset += snprintf(output_buf + offset, output_size - offset, 
-                              "Mount Point\tFlags\n");
-            offset += snprintf(output_buf + offset, output_size - offset, 
-                              "----------\t-----\n");
-
-            down_read(&mount_list_lock);
-            list_for_each_entry(entry, &mount_list, list) {
-                int written = snprintf(output_buf + offset, output_size - offset,
-                                      "%s\t%u\n", entry->umountable, entry->flags);
-                if (written < 0) {
-                    ret = -EFAULT;
-                    break;
-                }
-                if (written >= (int)(output_size - offset)) {
-                    ret = -ENOSPC;
-                    break;
-                }
-                offset += written;
-            }
-            up_read(&mount_list_lock);
-
-            if (ret == 0) {
-                if (copy_to_user((void __user *)cmd.arg, output_buf, offset)) {
-                    ret = -EFAULT;
-                }
-            }
-
-            kfree(output_buf);
-            return ret;
-        }
 		
 		default: {
 			pr_err("cmd_add_try_umount: invalid operation %u\n", cmd.mode);

--- a/kernel/supercalls.h
+++ b/kernel/supercalls.h
@@ -99,16 +99,14 @@ struct ksu_nuke_ext4_sysfs_cmd {
 };
 
 struct ksu_add_try_umount_cmd {
-	__aligned_u64 arg; // char ptr, this is the mountpoint (or output buffer for LIST)
+	__aligned_u64 arg; // char ptr, this is the mountpoint
 	__u32 flags; // this is the flag we use for it
-	__u8 mode; // denotes what to do with it 0:wipe_list 1:add_to_list 2:delete_entry 3:list
-	__u32 buf_size; // buffer size for LIST mode
+	__u8 mode; // denotes what to do with it 0:wipe_list 1:add_to_list 2:delete_entry
 };
 
 #define KSU_UMOUNT_WIPE 0  // ignore everything and wipe list
 #define KSU_UMOUNT_ADD 1   // add entry (path + flags)
 #define KSU_UMOUNT_DEL 2   // delete entry, strcmp
-#define KSU_UMOUNT_LIST 3  // list all entries
 
 
 // Other command structures
@@ -165,7 +163,7 @@ struct ksu_manual_su_cmd {
 #define KSU_IOCTL_GET_WRAPPER_FD _IOC(_IOC_WRITE, 'K', 15, 0)
 #define KSU_IOCTL_MANAGE_MARK _IOC(_IOC_READ|_IOC_WRITE, 'K', 16, 0)
 #define KSU_IOCTL_NUKE_EXT4_SYSFS _IOC(_IOC_WRITE, 'K', 17, 0)
-#define KSU_IOCTL_ADD_TRY_UMOUNT _IOC(_IOC_READ|_IOC_WRITE, 'K', 18, 0)
+#define KSU_IOCTL_ADD_TRY_UMOUNT _IOC(_IOC_WRITE, 'K', 18, 0)
 // Other IOCTL command definitions
 #define KSU_IOCTL_GET_FULL_VERSION _IOC(_IOC_READ, 'K', 100, 0)
 #define KSU_IOCTL_HOOK_TYPE _IOC(_IOC_READ, 'K', 101, 0)


### PR DESCRIPTION
Some root apps, such as some metamodule hardcode this struct we can't change that without break apps compatibility

This reverts commit d9c3db97bfe1221df84d2587ea231a13b3ee56b0.