### PR TITLE
Fix compile error in pkg_observer.c

### DIFF
--- a/kernel/pkg_observer.c
+++ b/kernel/pkg_observer.c
@@ -7,7 +7,9 @@
 #include <linux/rculist.h>
 #include <linux/version.h>
 #include "klog.h" // IWYU pragma: keep
+#include "ksu.h"
 #include "throne_tracker.h"
+#include "throne_comm.h"
 
 #define MASK_SYSTEM (FS_CREATE | FS_MOVE | FS_EVENT_ON_CHILD)
 
@@ -21,39 +23,64 @@ struct watch_dir {
 
 static struct fsnotify_group *g;
 
-static int ksu_handle_inode_event(struct fsnotify_mark *mark, u32 mask,
-				  struct inode *inode, struct inode *dir,
-				  const struct qstr *file_name, u32 cookie)
+#include "pkg_observer_defs.h" // KSU_DECL_FSNOTIFY_OPS
+static KSU_DECL_FSNOTIFY_OPS(ksu_handle_inode_event)
 {
 	if (!file_name)
 		return 0;
 	if (mask & FS_ISDIR)
 		return 0;
-	if (file_name->len == 13 &&
-		!memcmp(file_name->name, "packages.list", 13)) {
+	if (ksu_fname_len(file_name) == 13 &&
+		!memcmp(ksu_fname_arg(file_name), "packages.list", 13)) {
 		pr_info("packages.list detected: %d\n", mask);
+		if (ksu_uid_scanner_enabled) {
+			ksu_request_userspace_scan();
+		}
 		track_throne(false);
 	}
 	return 0;
 }
 
 static const struct fsnotify_ops ksu_ops = {
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 9, 0)
 	.handle_inode_event = ksu_handle_inode_event,
+#else
+	.handle_event = ksu_handle_inode_event,
+#endif
 };
+
+static void __maybe_unused m_free(struct fsnotify_mark *m)
+{
+	if (m) {
+		kfree(m);
+	}
+}
 
 static int add_mark_on_inode(struct inode *inode, u32 mask,
 				 struct fsnotify_mark **out)
 {
 	struct fsnotify_mark *m;
+	int ret;
 
 	m = kzalloc(sizeof(*m), GFP_KERNEL);
 	if (!m)
 		return -ENOMEM;
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 18, 0)
 	fsnotify_init_mark(m, g);
 	m->mask = mask;
+	ret = fsnotify_add_inode_mark(m, inode, 0);
+#elif LINUX_VERSION_CODE >= KERNEL_VERSION(4, 12, 0)
+	fsnotify_init_mark(m, g);
+	m->mask = mask;
+	ret = fsnotify_add_mark(m, inode, NULL, 0);
+#else
+	fsnotify_init_mark(m, m_free);
+	m->mask = mask;
+	ret = fsnotify_add_mark(m, g, inode, NULL, 0);
+#endif
 
-	if (fsnotify_add_inode_mark(m, inode, 0)) {
+	if (ret) {
 		fsnotify_put_mark(m);
 		return -EINVAL;
 	}

--- a/kernel/pkg_observer_defs.h
+++ b/kernel/pkg_observer_defs.h
@@ -1,0 +1,48 @@
+// This header should not be used outside of pkg_observer.c!
+
+#include <linux/version.h>
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 2, 0)
+typedef const struct qstr *ksu_fname_t;
+#define ksu_fname_len(f) ((f)->len)
+#define ksu_fname_arg(f) ((f)->name)
+#else
+typedef const unsigned char *ksu_fname_t;
+#define ksu_fname_len(f) (strlen(f))
+#define ksu_fname_arg(f) (f)
+#endif
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 9, 0)
+#define KSU_DECL_FSNOTIFY_OPS(name) \
+int name(struct fsnotify_mark *mark, u32 mask, \
+	struct inode *inode, struct inode *dir, \
+	const struct qstr *file_name, u32 cookie)
+#elif LINUX_VERSION_CODE >= KERNEL_VERSION(5, 2, 0)
+#define KSU_DECL_FSNOTIFY_OPS(name) \
+int name(struct fsnotify_group *group, \
+	struct inode *inode, u32 mask, const void *data, int data_type, \
+	ksu_fname_t file_name, u32 cookie, \
+	struct fsnotify_iter_info *iter_info)
+#elif LINUX_VERSION_CODE >= KERNEL_VERSION(4, 18, 0)
+#define KSU_DECL_FSNOTIFY_OPS(name) \
+int name(struct fsnotify_group *group, \
+	struct inode *inode, u32 mask, const void *data, int data_type, \
+	ksu_fname_t file_name, u32 cookie, \
+	struct fsnotify_iter_info *iter_info)
+#elif LINUX_VERSION_CODE >= KERNEL_VERSION(4, 12, 0)
+#define KSU_DECL_FSNOTIFY_OPS(name) \
+int name(struct fsnotify_group *group, \
+	struct inode *inode, struct fsnotify_mark *inode_mark, \
+	struct fsnotify_mark *vfsmount_mark, \
+	u32 mask, const void *data, int data_type, \
+	ksu_fname_t file_name, u32 cookie, \
+	struct fsnotify_iter_info *iter_info)
+#else
+#define KSU_DECL_FSNOTIFY_OPS(name) \
+int name(struct fsnotify_group *group, \
+	struct inode *inode, \
+	struct fsnotify_mark *inode_mark, \
+	struct fsnotify_mark *vfsmount_mark, \
+	u32 mask, void *data, int data_type, \
+	ksu_fname_t file_name, u32 cookie)
+#endif


### PR DESCRIPTION
After commit 9d994cc, much of the code for non-GKI kernel compatibility was lost. 
This pull request ported some code based on the state of https://github.com/SukiSU-Ultra/SukiSU-Ultra/tree/8da27430ff54e2e5bd57435684132581f9d310e0 to help maintain compatibility.

fix #680 maybe