### PR TITLE
Ensure paths are saved as immutable sets

### DIFF
--- a/manager/app/src/main/java/com/sukisu/ultra/ui/susfs/util/SuSFSManager.kt
+++ b/manager/app/src/main/java/com/sukisu/ultra/ui/susfs/util/SuSFSManager.kt
@@ -346,32 +346,32 @@ object SuSFSManager {
 
     // 路径和配置管理
     fun saveSusPaths(context: Context, paths: Set<String>) =
-        getPrefs(context).edit { putStringSet(KEY_SUS_PATHS, paths) }
+        getPrefs(context).edit { putStringSet(KEY_SUS_PATHS, paths.toSet()) }
 
     fun getSusPaths(context: Context): Set<String> =
         getPrefs(context).getStringSet(KEY_SUS_PATHS, emptySet()) ?: emptySet()
 
     // 循环路径管理
     fun saveSusLoopPaths(context: Context, paths: Set<String>) =
-        getPrefs(context).edit { putStringSet(KEY_SUS_LOOP_PATHS, paths) }
+        getPrefs(context).edit { putStringSet(KEY_SUS_LOOP_PATHS, paths.toSet()) }
 
     fun getSusLoopPaths(context: Context): Set<String> =
         getPrefs(context).getStringSet(KEY_SUS_LOOP_PATHS, emptySet()) ?: emptySet()
 
     fun saveSusMaps(context: Context, maps: Set<String>) =
-        getPrefs(context).edit { putStringSet(KEY_SUS_MAPS, maps) }
+        getPrefs(context).edit { putStringSet(KEY_SUS_MAPS, maps.toSet()) }
 
     fun getSusMaps(context: Context): Set<String> =
         getPrefs(context).getStringSet(KEY_SUS_MAPS, emptySet()) ?: emptySet()
 
     fun saveKstatConfigs(context: Context, configs: Set<String>) =
-        getPrefs(context).edit { putStringSet(KEY_KSTAT_CONFIGS, configs) }
+        getPrefs(context).edit { putStringSet(KEY_KSTAT_CONFIGS, configs.toSet()) }
 
     fun getKstatConfigs(context: Context): Set<String> =
         getPrefs(context).getStringSet(KEY_KSTAT_CONFIGS, emptySet()) ?: emptySet()
 
     fun saveAddKstatPaths(context: Context, paths: Set<String>) =
-        getPrefs(context).edit { putStringSet(KEY_ADD_KSTAT_PATHS, paths) }
+        getPrefs(context).edit { putStringSet(KEY_ADD_KSTAT_PATHS, paths.toSet()) }
 
     fun getAddKstatPaths(context: Context): Set<String> =
         getPrefs(context).getStringSet(KEY_ADD_KSTAT_PATHS, emptySet()) ?: emptySet()
@@ -662,7 +662,7 @@ object SuSFSManager {
                     is Boolean -> putBoolean(key, value)
                     is Set<*> -> {
                         @Suppress("UNCHECKED_CAST")
-                        putStringSet(key, value as Set<String>)
+                        putStringSet(key, (value as Set<String>).toSet())
                     }
                     is Int -> putInt(key, value)
                     is Long -> putLong(key, value)


### PR DESCRIPTION
This pull request makes minor improvements to how sets are saved to shared preferences in the `SuSFSManager` utility. The main change is to ensure that all sets passed to `putStringSet` are explicitly converted to a new set using `.toSet()`, which helps avoid unexpected behavior if the original set is mutable.

**Shared Preferences Handling:**

* All `putStringSet` calls in functions like `saveSusPaths`, `saveSusLoopPaths`, `saveSusMaps`, `saveKstatConfigs`, and `saveAddKstatPaths` now wrap the input set with `.toSet()` to ensure immutability when saving to preferences.
* In the generic preferences setter, the `Set<String>` value is also wrapped with `.toSet()` before being saved via `putStringSet`.Fix SharedPreferences putStringSet caching bug with defensive copies