### PR TITLE
fix: 'struct kstat' will not be visible

### DIFF
--- a/kernel/setuid_hook.c
+++ b/kernel/setuid_hook.c
@@ -13,6 +13,7 @@
 #include <linux/types.h>
 #include <linux/uaccess.h>
 #include <linux/uidgid.h>
+#include <linux/stat.h>
 
 #ifdef CONFIG_KSU_SUSFS
 #include <linux/susfs.h>


### PR DESCRIPTION
After committing https://github.com/SukiSU-Ultra/SukiSU-Ultra/commit/fc8d283e2e3ebacf939d4b755e44ed358f397a36, the following build errors persist:

```
In file included from ../drivers/kernelsu/setuid_hook.c:18:
../include/linux/susfs.h:180:67: error: declaration of 'struct kstat' will not be visible outside of this function [-Werror,-Wvisibility]
  180 | void susfs_sus_ino_for_generic_fillattr(unsigned long ino, struct kstat *stat);
      |                                                                   ^
1 error generated.
```

This commit adds the missing header file to resolve the issue https://github.com/SukiSU-Ultra/SukiSU-Ultra/issues/720.