### PR TITLE
feat: detect ns_get_path type is int instead of version check.

### DIFF
--- a/kernel/Kbuild
+++ b/kernel/Kbuild
@@ -194,6 +194,11 @@ ifeq ($(shell grep -q "struct proc_ops " $(srctree)/include/linux/proc_fs.h; ech
 ccflags-y += -DKSU_COMPAT_HAS_PROC_OPS
 endif
 
+# Type ns_get_path check
+ifeq ($(shell grep -q "int ns_get_path" $(srctree)/include/linux/proc_ns.h; echo $$?),0)
+ccflags-y += -DKSU_TYPE_INT_NS_GET_PATH
+endif
+
 # Custom Signs
 ifdef KSU_EXPECTED_SIZE
 ccflags-y += -DEXPECTED_SIZE=$(KSU_EXPECTED_SIZE)

--- a/kernel/su_mount_ns.c
+++ b/kernel/su_mount_ns.c
@@ -84,7 +84,7 @@ int ksys_unshare(unsigned long unshare_flags)
 }
 #endif
 
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 6, 0)
+#ifdef KSU_TYPE_INT_NS_GET_PATH
 	typedef long  ns_ret_t;
 	#define NS_RET_OK(r)   ((r) == 0)
 	#define NS_RET_ERR(r)  (r)


### PR DESCRIPTION
Some older kernels have bettered the kernel by porting the int type definition and replacing it with the original void type definition.

Therefore, in this case, we need to adopt different detection ideas to circumvent the compilation errors caused by wrong type definitions.