### PR TITLE
kernel: ksud: Refine rc injection, fix issue of Android Canary 2601

### DIFF
--- a/kernel/arch.h
+++ b/kernel/arch.h
@@ -21,6 +21,9 @@
 #define REBOOT_SYMBOL "__arm64_sys_reboot"
 #define SYS_READ_SYMBOL "__arm64_sys_read"
 #define SYS_EXECVE_SYMBOL "__arm64_sys_execve"
+// https://cs.android.com/android/kernel/superproject/+/common-android-mainline:common/scripts/syscalltbl.sh;l=57;drc=9142be9e6443fd641ca37f820efe00d9cd890eb1
+// https://cs.android.com/android/kernel/superproject/+/common-android-mainline:common/scripts/syscall.tbl;l=104;drc=b36d4b6aa88ef039647228b98c59a875e92f8c8e
+#define SYS_FSTAT_SYMBOL "__arm64_sys_newfstat"
 
 extern long __arm64_sys_setns(const struct pt_regs *regs);
 
@@ -65,6 +68,7 @@ extern long sys_setns(const struct pt_regs *regs);
 #define REBOOT_SYMBOL "__x64_sys_reboot"
 #define SYS_READ_SYMBOL "__x64_sys_read"
 #define SYS_EXECVE_SYMBOL "__x64_sys_execve"
+#define SYS_NEWFSTATAT_SYMBOL "__x64_sys_newfstat"
 
 extern long __x64_sys_setns(const struct pt_regs *regs);
 

--- a/kernel/kp_hook.c
+++ b/kernel/kp_hook.c
@@ -8,6 +8,14 @@
 		.pre_handler = pre,                                            \
 	}
 
+#define DECL_KRP(name, sym, ent, han)                                                \
+	struct kretprobe name = {                                                 \
+		.kp.symbol_name = sym,                                            \
+		.entry_handler = ent,                                            \
+		.handler = han,                                            \
+		.data_size = sizeof(void *),
+	}
+
 // ksud.c
 
 static struct work_struct stop_vfs_read_work, stop_execve_hook_work,
@@ -40,10 +48,53 @@ static int sys_read_handler_pre(struct kprobe *p, struct pt_regs *regs)
 {
 	struct pt_regs *real_regs = PT_REAL_REGS(regs);
 	unsigned int fd = PT_REGS_PARM1(real_regs);
-	char __user **buf_ptr = (char __user **)&PT_REGS_PARM2(real_regs);
-	size_t *count_ptr = (size_t *)&PT_REGS_PARM3(real_regs);
+	ksu_handle_sys_read(fd);
+	return 0;
+}
 
-	return ksu_handle_sys_read(fd, buf_ptr, count_ptr);
+static int sys_fstat_handler_pre(struct kretprobe_instance *p,
+					struct pt_regs *regs)
+{
+	struct pt_regs *real_regs = PT_REAL_REGS(regs);
+	unsigned int fd = PT_REGS_PARM1(real_regs);
+	void *statbuf = PT_REGS_PARM2(real_regs);
+	*(void **)&p->data = NULL;
+
+	struct file *file = fget(fd);
+	if (!file)
+		return 1;
+	if (is_init_rc(file)) {
+		pr_info("stat init.rc");
+		fput(file);
+		*(void **)&p->data = statbuf;
+		return 0;
+	}
+	fput(file);
+	return 1;
+}
+
+static int sys_fstat_handler_post(struct kretprobe_instance *p,
+					struct pt_regs *regs)
+{
+	void __user *statbuf = *(void **)&p->data;
+	if (statbuf) {
+		void __user *st_size_ptr = statbuf + offsetof(struct stat, st_size);
+		long size, new_size;
+		if (!copy_from_user_nofault(&size, st_size_ptr, sizeof(long))) {
+			new_size = size + ksu_rc_len;
+			pr_info("adding ksu_rc_len: %ld -> %ld", size, new_size);
+			if (!copy_to_user_nofault(st_size_ptr, &new_size, sizeof(long))) {
+				pr_info("added ksu_rc_len");
+			} else {
+				pr_err("add ksu_rc_len failed: statbuf 0x%lx",
+					(unsigned long)st_size_ptr);
+			}
+		} else {
+			pr_err("read statbuf 0x%lx failed", (unsigned long)st_size_ptr);
+		}
+	}
+
+	return 0;
 }
 
 static int input_handle_event_handler_pre(struct kprobe *p,
@@ -56,12 +107,14 @@ static int input_handle_event_handler_pre(struct kprobe *p,
 }
 
 static DECL_KP(execve_kp, SYS_EXECVE_SYMBOL, sys_execve_handler_pre);
-static DECL_KP(vfs_read_kp, SYS_READ_SYMBOL, sys_read_handler_pre);
+static DECL_KP(sys_read_kp, SYS_READ_SYMBOL, sys_read_handler_pre);
+static DECL_KRP(sys_fstat_kp, SYS_FSTAT_SYMBOL, sys_fstat_handler_pre, sys_fstat_handler_post);
 static DECL_KP(input_event_kp, "input_event", input_handle_event_handler_pre);
 
-static void do_stop_vfs_read_hook(struct work_struct *work)
+static void do_stop_init_rc_hook(struct work_struct *work)
 {
-	unregister_kprobe(&vfs_read_kp);
+	unregister_kprobe(&sys_read_kp);
+	unregister_kretprobe(&sys_fstat_kp);
 }
 
 static void do_stop_execve_hook(struct work_struct *work)
@@ -79,9 +132,9 @@ void kp_handle_ksud_stop(enum ksud_stop_code stop_code)
 {
 	bool ret;
 	switch (stop_code) {
-	case VFS_READ_HOOK_KP: {
-		ret = schedule_work(&stop_vfs_read_work);
-		pr_info("unregister vfs_read kprobe: %d!\n", ret);
+	case INIT_RC_HOOK_KP: {
+		ret = schedule_work(&stop_init_rc_hook_work);
+		pr_info("unregister init_rc_hook kprobe: %d!\n", ret);
 		break;
 	}
 	case EXECVE_HOOK_KP: {
@@ -112,13 +165,16 @@ void kp_handle_ksud_init(void)
 	ret = register_kprobe(&execve_kp);
 	pr_info("ksud: execve_kp: %d\n", ret);
 
-	ret = register_kprobe(&vfs_read_kp);
-	pr_info("ksud: vfs_read_kp: %d\n", ret);
+	ret = register_kprobe(&sys_read_kp);
+	pr_info("ksud: sys_read_kp: %d\n", ret);
+
+	ret = register_kretprobe(&sys_fstat_kp);
+	pr_info("ksud: sys_fstat_kp: %d\n", ret);
 
 	ret = register_kprobe(&input_event_kp);
 	pr_info("ksud: input_event_kp: %d\n", ret);
 
-	INIT_WORK(&stop_vfs_read_work, do_stop_vfs_read_hook);
+	INIT_WORK(&stop_init_rc_hook_work, do_stop_init_rc_hook);
 	INIT_WORK(&stop_execve_hook_work, do_stop_execve_hook);
 	INIT_WORK(&stop_input_hook_work, do_stop_input_hook);
 }
@@ -126,8 +182,8 @@ void kp_handle_ksud_init(void)
 void kp_handle_ksud_exit(void)
 {
 	unregister_kprobe(&execve_kp);
-	// this should be done before unregister vfs_read_kp
-	// unregister_kprobe(&vfs_read_kp);
+	// this should be done before unregister sys_read_kp
+	// unregister_kprobe(&sys_read_kp);
 	unregister_kprobe(&input_event_kp);
 }
 

--- a/kernel/kp_hook.h
+++ b/kernel/kp_hook.h
@@ -3,7 +3,7 @@
 
 // ksud.c
 enum ksud_stop_code {
-	VFS_READ_HOOK_KP = 0,
+	INIT_RC_HOOK_KP = 0,
 	EXECVE_HOOK_KP,
 	INPUT_EVENT_HOOK_KP,
 };

--- a/kernel/ksud.c
+++ b/kernel/ksud.c
@@ -76,12 +76,12 @@ static const char KERNEL_SU_RC[] =
 
 	"\n";
 
-static void stop_vfs_read_hook(void);
+static void stop_init_rc_hook(void);
 static void stop_execve_hook(void);
 static void stop_input_hook(void);
 
 #if defined(CONFIG_KSU_MANUAL_HOOK) || defined(CONFIG_KSU_SUSFS)
-bool ksu_vfs_read_hook __read_mostly = true;
+bool ksu_init_rc_hook __read_mostly = true;
 bool ksu_execveat_hook __read_mostly = true;
 bool ksu_input_hook __read_mostly = true;
 #endif // #ifndef CONFIG_KSU_SUSFS
@@ -476,64 +476,60 @@ static bool check_init_path(char *dpath)
 	return true;
 }
 
-int ksu_handle_vfs_read(struct file **file_ptr, char __user **buf_ptr,
-			size_t *count_ptr, loff_t **pos)
+static bool is_init_rc(struct file *fp)
 {
-#if defined(CONFIG_KSU_MANUAL_HOOK) || defined(CONFIG_KSU_SUSFS)
-	if (!ksu_vfs_read_hook) {
-		return 0;
-	}
-#endif
-
-	struct file *file;
-
-	size_t count;
-
 	if (strcmp(current->comm, "init")) {
 		// we are only interest in `init` process
-		return 0;
+		return false;
 	}
 
-	file = *file_ptr;
-	if (IS_ERR(file)) {
-		return 0;
+	if (!d_is_reg(fp->f_path.dentry)) {
+		return false;
 	}
 
-	if (!d_is_reg(file->f_path.dentry)) {
-		return 0;
-	}
-
-	const char *short_name = file->f_path.dentry->d_name.name;
+	const char *short_name = fp->f_path.dentry->d_name.name;
 	if (strcmp(short_name, "init.rc")) {
 		// we are only interest `init.rc` file name file
-		return 0;
+		return false;
 	}
 	char path[256];
-	char *dpath = d_path(&file->f_path, path, sizeof(path));
+	char *dpath = d_path(&fp->f_path, path, sizeof(path));
 
 	if (IS_ERR(dpath)) {
-		return 0;
+		return false;
 	}
 
 	if (!check_init_path(dpath)) {
-		return 0;
+		return false;
+	}
+
+	return true;
+}
+
+static void ksu_handle_sys_read(unsigned int fd)
+{
+	struct file *file = fget(fd);
+	if (!file) {
+		return;
+	}
+
+	if (!is_init_rc(file)) {
+		goto skip;
 	}
 
 	// we only process the first read
 	static bool rc_hooked = false;
 	if (rc_hooked) {
-		// we don't need this kprobe, unregister it!
-		stop_vfs_read_hook();
-		return 0;
+		// we don't need these kprobe, unregister it!
+		stop_init_rc_hook();
+		goto skip;
 	}
 	rc_hooked = true;
 
 	// now we can sure that the init process is reading
 	// `/system/etc/init/hw/init.rc` or `/init.rc`
-	count = *count_ptr;
-
-	pr_info("vfs_read: %s, comm: %s, count: %zu, rc_count: %zu\n", dpath,
-		current->comm, count, ksu_rc_len);
+	pr_info("read init.rc, comm: %s, rc_count: %zu\n", current->comm,
+		ksu_rc_len);
 
 	// Now we need to proxy the read and modify the result!
 	// But, we can not modify the file_operations directly, because it's in read-only memory.
@@ -550,23 +546,8 @@ int ksu_handle_vfs_read(struct file **file_ptr, char __user **buf_ptr,
 	// replace the file_operations
 	file->f_op = &fops_proxy;
 
-	return 0;
-}
-int ksu_handle_sys_read(unsigned int fd, char __user **buf_ptr,
-			size_t *count_ptr)
-{
-#if defined(CONFIG_KSU_SYSCALL_HOOK) || defined(CONFIG_KSU_SUSFS)
-	struct file *file = fget(fd);
-	if (!file) {
-		return 0;
-	}
-	int result = ksu_handle_vfs_read(&file, buf_ptr, count_ptr, NULL);
+skip:
 	fput(file);
-	return result;
-#else
-	/* Do nothing */
-	return 0;
-#endif
 }
 
 static unsigned int volumedown_pressed_count = 0;
@@ -604,12 +585,12 @@ bool ksu_is_safe_mode(void)
 	return is_volumedown_enough(volumedown_pressed_count);
 }
 
-static void stop_vfs_read_hook(void)
+static void stop_init_rc_hook(void)
 {
 #ifdef CONFIG_KSU_SYSCALL_HOOK
-	kp_handle_ksud_stop(VFS_READ_HOOK_KP);
+	kp_handle_ksud_stop(INIT_RC_HOOK_KP);
 #else
-	ksu_vfs_read_hook = false;
+	ksu_init_rc_hook = false;
 	pr_info("stop vfs_read_hook\n");
 #endif // #ifndef CONFIG_KSU_SUSFS
 }


### PR DESCRIPTION
kernel: ksud: Refine rc injection, fix issue of Android Canary 2601

Author: 5ec1cff [ewtqyqyewtqyqy@gmail.com](mailto:ewtqyqyewtqyqy@gmail.com)
Date: Sat Jan 10 04:10:49 2026 +0000

Since Android Canary version 2601, the libbase ReadFdToString function only reads the number of bytes returned by fstat. We need to modify the st_size returned by fstat so that the init can read the injected rc.

https://github.com/tiann/KernelSU/commit/df640917d11dd0eff1b34ea53ec3c0dc49667002