### PR TITLE
kernel: ksud: fix build for KSU_SYSCALL_HOOK guard

### DIFF
--- a/kernel/kp_hook.c
+++ b/kernel/kp_hook.c
@@ -13,7 +13,7 @@
 		.kp.symbol_name = sym,                                            \
 		.entry_handler = ent,                                            \
 		.handler = han,                                            \
-		.data_size = sizeof(void *),
+		.data_size = sizeof(void *),                             \
 	}
 
 // ksud.c

--- a/kernel/ksud.c
+++ b/kernel/ksud.c
@@ -514,8 +514,8 @@ static bool is_init_rc(struct file *fp)
 
 void ksu_handle_sys_read(unsigned int fd)
 {
-#ifdef CONFIG_KSU_SYSCALL_HOOK
 	struct file *file = fget(fd);
+#if defined(CONFIG_KSU_SYSCALL_HOOK)
 	if (!file) {
 		return;
 	}
@@ -525,7 +525,7 @@ void ksu_handle_sys_read(unsigned int fd)
 	}
 #else
 	/* Do nothing */
-	return false;
+	return;
 #endif
 
 	// we only process the first read


### PR DESCRIPTION
Enabling CONFIG_KSU_SUSFS check again because there are major network issues after removing that like wireless hotspot not working, and also resulting in the function always returning false when susfs is enabled. I also added a slash which I missed during my earlier commit.