### PR TITLE
Apply modification for SukiSU compatibility

### DIFF
--- a/kernel/app_profile.c
+++ b/kernel/app_profile.c
@@ -383,7 +383,7 @@ void escape_to_root_for_cmd_su(uid_t target_uid, pid_t target_pid)
 		disable_seccomp_for_task(target_task);
 	}
 
-	setup_selinux(profile->selinux_domain, cred);
+	setup_selinux(profile->selinux_domain, newcreds);
 	put_cred(old_creds);
 	wake_up_process(target_task);
 


### PR DESCRIPTION
Due to custom modifications made by SukiSU, the parameter name passed to the function needs to be changed.