### PR TITLE
fix type error

### DIFF
--- a/kernel/supercalls.c
+++ b/kernel/supercalls.c
@@ -659,7 +659,7 @@ static int list_try_umount(void __user *arg)
 		output_size = MAX_UMOUNT_LIST_SIZE;
 
 	pr_info("KernelSU: Allocating %zu bytes for %d mounts (user requested %zu)\n",
-	        output_size, mount_count, cmd.buf_size);
+	        output_size, mount_count, (size_t)cmd.buf_size);
 
 	// Try kzalloc first with NOWARN flag
 	output_buf = kzalloc(output_size, GFP_KERNEL | __GFP_NOWARN);


### PR DESCRIPTION
I encountered the following error when compiling.
<img width="1603" height="406" alt=") {F5 2(}%(8 (1K@%TN5TG" src="https://github.com/user-attachments/assets/fb869577-4223-4c65-81e3-c9af76c2cc57" />
So I added type conversion below.