### PR TITLE
kernel: Fix duplicate function

### DIFF
--- a/kernel/ksuinit.c
+++ b/kernel/ksuinit.c
@@ -39,7 +39,7 @@
 #include <linux/stackprotector.h>
 #include <linux/random.h>
 unsigned long __stack_chk_guard __ro_after_init
-    __attribute__((visibility("hidden")));
+    __attribute__((weak, visibility("hidden")));
 #define NO_STACK_PROTECTOR_WORKAROUND __attribute__((no_stack_protector))
 #else
 #define NO_STACK_PROTECTOR_WORKAROUND


### PR DESCRIPTION
For Built-in, there is no need to introduce additional __stack_chk_guard functions. So far compatibility, we need to let the compiler detect if the function already exists to get around the duplicate function problem. This ensures that LKM requirments are met while also allowing Built-in to compile smoothly.