### PR TITLE
fix: remove unmatched #endif in allowlist.c

### DIFF
--- a/kernel/policy/allowlist.c
+++ b/kernel/policy/allowlist.c
@@ -339,7 +339,7 @@ retry:
 
     rcu_read_unlock();
     return res;
-#endif
+// #endif
 }
 
 void ksu_put_root_profile(struct root_profile *profile)


### PR DESCRIPTION
Removes a stray `#endif` at line 342 that causes the compiler to crash with an `#endif without #if` error during `ksu.o` compilation.