### PR TITLE
manager: Use Long for versionCode to support values exceeding Int.MAX…

### DIFF
--- a/manager/app/src/main/java/com/sukisu/ultra/data/model/Module.kt
+++ b/manager/app/src/main/java/com/sukisu/ultra/data/model/Module.kt
@@ -8,7 +8,7 @@ data class Module(
     val name: String,
     val author: String,
     val version: String,
-    val versionCode: Int,
+    val versionCode: Long,
     val description: String,
     val enabled: Boolean,
     val update: Boolean,

--- a/manager/app/src/main/java/com/sukisu/ultra/data/model/RepoModule.kt
+++ b/manager/app/src/main/java/com/sukisu/ultra/data/model/RepoModule.kt
@@ -28,6 +28,6 @@ data class RepoModule(
     val createdAt: String,
     val latestRelease: String,
     val latestReleaseTime: String,
-    val latestVersionCode: Int,
+    val latestVersionCode: Long,
     val latestAsset: ReleaseAsset?,
 )

--- a/manager/app/src/main/java/com/sukisu/ultra/data/repository/ModuleRepoRepositoryImpl.kt
+++ b/manager/app/src/main/java/com/sukisu/ultra/data/repository/ModuleRepoRepositoryImpl.kt
@@ -67,7 +67,7 @@ class ModuleRepoRepositoryImpl : ModuleRepoRepository {
 
         var latestRelease = ""
         var latestReleaseTime = ""
-        var latestVersionCode = 0
+        var latestVersionCode = 0L
         var latestAsset: ReleaseAsset? = null
         val lr = item.optJSONObject("latestRelease")
         if (lr != null) {
@@ -83,9 +83,9 @@ class ModuleRepoRepositoryImpl : ModuleRepoRepository {
             }
             val vcAny = lr.opt("versionCode")
             latestVersionCode = when (vcAny) {
-                is Number -> vcAny.toInt()
-                is String -> vcAny.toIntOrNull() ?: 0
-                else -> 0
+                is Number -> vcAny.toLong()
+                is String -> vcAny.toLongOrNull() ?: 0L
+                else -> 0L
             }
             latestRelease = lrName
             latestReleaseTime = lrTime

--- a/manager/app/src/main/java/com/sukisu/ultra/data/repository/ModuleRepositoryImpl.kt
+++ b/manager/app/src/main/java/com/sukisu/ultra/data/repository/ModuleRepositoryImpl.kt
@@ -31,7 +31,7 @@ class ModuleRepositoryImpl : ModuleRepository {
                         name = obj.optString("name"),
                         author = obj.optString("author", "Unknown"),
                         version = obj.optString("version", "Unknown"),
-                        versionCode = obj.optInt("versionCode", 0),
+                        versionCode = obj.optLong("versionCode", 0L),
                         description = obj.optString("description"),
                         enabled = obj.getBoolean("enabled"),
                         update = obj.optBoolean("update"),
@@ -74,7 +74,7 @@ class ModuleRepositoryImpl : ModuleRepository {
             val updateJson = JSONObject(result)
             var version = updateJson.optString("version", "")
             version = sanitizeVersionString(version)
-            val versionCode = updateJson.optInt("versionCode", 0)
+            val versionCode = updateJson.optLong("versionCode", 0L)
             val zipUrl = updateJson.optString("zipUrl", "")
             val changelog = updateJson.optString("changelog", "")
 

--- a/manager/app/src/main/java/com/sukisu/ultra/ui/util/Downloader.kt
+++ b/manager/app/src/main/java/com/sukisu/ultra/ui/util/Downloader.kt
@@ -68,7 +68,7 @@ fun checkNewVersion(): LatestVersionInfo {
                     val regex = Regex("v(.+?)_(\\d+)-")
                     val matchResult = regex.find(name) ?: continue
                     matchResult.groupValues[1]
-                    val versionCode = matchResult.groupValues[2].toInt()
+                    val versionCode = matchResult.groupValues[2].toLong()
                     val downloadUrl = asset.getString("browser_download_url")
 
                     return LatestVersionInfo(

--- a/manager/app/src/main/java/com/sukisu/ultra/ui/util/module/LatestVersionInfo.kt
+++ b/manager/app/src/main/java/com/sukisu/ultra/ui/util/module/LatestVersionInfo.kt
@@ -1,7 +1,7 @@
 package com.sukisu.ultra.ui.util.module
 
 data class LatestVersionInfo(
-    val versionCode: Int = 0,
+    val versionCode: Long = 0L,
     val downloadUrl: String = "",
     val changelog: String = ""
 )

--- a/manager/app/src/main/java/com/sukisu/ultra/ui/viewmodel/ModuleViewModel.kt
+++ b/manager/app/src/main/java/com/sukisu/ultra/ui/viewmodel/ModuleViewModel.kt
@@ -51,7 +51,7 @@ class ModuleViewModel(
 
     private data class ModuleUpdateSignature(
         val updateJson: String,
-        val versionCode: Int,
+        val versionCode: Long,
         val enabled: Boolean,
         val update: Boolean,
         val remove: Boolean


### PR DESCRIPTION
Fixed an issue where `versionCode` would get stuck at `2147483647`. Updated data type to `Long` to support larger version numbers.