### PR TITLE
Fix build errors

### DIFF
--- a/kernel/infra/kernel_compat.h
+++ b/kernel/infra/kernel_compat.h
@@ -253,3 +253,5 @@ __weak void groups_sort(struct group_info *group_info)
 #define KSU_COMPAT_USE_STATIC_KEY
 
 #endif
+
+#endif

--- a/kernel/runtime/ksud.c
+++ b/kernel/runtime/ksud.c
@@ -29,7 +29,7 @@ static void stop_vfs_read_hook();
 static void stop_execve_hook();
 static void stop_input_hook();
 
-#if defined(CONFIG_KSU_SUSFS) && KSU_COMPAT_USE_STATIC_KEY
+#if defined(CONFIG_KSU_SUSFS) && defined(KSU_COMPAT_USE_STATIC_KEY)
 extern struct static_key_false ksu_init_rc_hook_key_false;
 extern struct static_key_false ksu_input_hook_key_false;
 #else
@@ -674,7 +674,7 @@ static int vol_detector_exit(void)
 
 static void stop_vfs_read_hook(void)
 {
-#if defined(CONFIG_KSU_SUSFS) && KSU_COMPAT_USE_STATIC_KEY
+#if defined(CONFIG_KSU_SUSFS) && defined(KSU_COMPAT_USE_STATIC_KEY)
     if (static_key_enabled(&ksu_init_rc_hook_key_false))
         static_branch_disable(&ksu_init_rc_hook_key_false);
     pr_info("disabling ksu_init_rc_hook_key_false\n");
@@ -692,7 +692,7 @@ static void stop_execve_hook(void)
 
 static void stop_input_hook(void)
 {
-#if defined(CONFIG_KSU_SUSFS) && KSU_COMPAT_USE_STATIC_KEY 
+#if defined(CONFIG_KSU_SUSFS) && defined(KSU_COMPAT_USE_STATIC_KEY)
     if (static_key_enabled(&ksu_input_hook_key_false)) {
         static_branch_disable(&ksu_input_hook_key_false);
         pr_info("disabling ksu_input_hook_key_false\n");


### PR DESCRIPTION
Fix unterminated conditional directive in kernel_compat.h (missing #endif)
Fix expected value in expression by adding defined() check for KSU_COMPAT_USE_STATIC_KEY in ksud.c