### PR TITLE
Fix missing #endif in sucompat.c

### DIFF
--- a/kernel/feature/sucompat.c
+++ b/kernel/feature/sucompat.c
@@ -350,7 +350,7 @@ int ksu_handle_execveat(int *fd, struct filename **filename_ptr, void *argv, voi
 
     return ksu_handle_execveat_sucompat(fd, filename_ptr, argv, envp, flags);
 }
-
+#endif
 // dead code
 int __maybe_unused ksu_handle_devpts(struct inode *inode)
 {


### PR DESCRIPTION
We're missing an endif in sucompat.c, which is causing the kernel compilation process to fail. We should fix it so that the compilation can complete.