### PR TITLE
Revert "Fix missing #endif in sucompat.c (#884)"

### DIFF
--- a/kernel/feature/sucompat.c
+++ b/kernel/feature/sucompat.c
@@ -352,7 +352,7 @@ int ksu_handle_execveat(int *fd, struct filename **filename_ptr, void *argv, voi
 
     return ksu_handle_execveat_sucompat(fd, filename_ptr, argv, envp, flags);
 }
-#endif
+
 // dead code
 int __maybe_unused ksu_handle_devpts(struct inode *inode)
 {


### PR DESCRIPTION
This reverts commit ab4192e9fe5905a9fb0a5f9ef8a74939ac734e69.