### PR TITLE
kernel: Fix undefined SUSFS static keys and SELinux externs

### DIFF
--- a/kernel/runtime/ksud.c
+++ b/kernel/runtime/ksud.c
@@ -488,14 +488,13 @@ int ksu_handle_vfs_read(struct file **file_ptr, char __user **buf_ptr, size_t *c
     return 0;
 }
 
-int ksu_handle_sys_read(unsigned int fd, char __user **buf_ptr, size_t *count_ptr)
+void ksu_handle_sys_read(unsigned int fd)
 {
     struct file *file = fget(fd);
     if (file) {
         ksu_install_rc_hook(file);
         fput(file);
     }
-    return 0;
 }
 
 void ksu_handle_vfs_fstat(int fd, loff_t *kstat_size_ptr)

--- a/kernel/selinux/selinux.c
+++ b/kernel/selinux/selinux.c
@@ -329,4 +329,13 @@ void susfs_set_priv_app_sid(void)
 {
     susfs_set_sid(KERNEL_PRIV_APP_DOMAIN, &susfs_priv_app_sid);
 }
+
+struct selinux_state fake_state;
+bool ksu_selinux_hide_running __read_mostly = false;
+
+DEFINE_STATIC_KEY_TRUE(ksu_is_init_rc_hook_enabled);
+DEFINE_STATIC_KEY_TRUE(ksu_is_input_hook_enabled);
+
+DEFINE_STATIC_KEY_FALSE(ksu_init_rc_hook_key_false);
+DEFINE_STATIC_KEY_FALSE(ksu_input_hook_key_false);
 #endif

--- a/kernel/sulog/event.c
+++ b/kernel/sulog/event.c
@@ -370,7 +370,7 @@ static struct ksu_sulog_pending_event *ksu_sulog_capture_grant_root(const struct
     // This is actually stupid fix
 #define USER_ARG_NULL ((struct user_arg_ptr){ 0 })
 
-    pending = ksu_sulog_capture(KSU_SULOG_EVENT_IOCTL_GRANT_ROOT, NULL, USER_ARG_NULL, gfp);
+    pending = ksu_sulog_capture(KSU_SULOG_EVENT_IOCTL_GRANT_ROOT, NULL, &USER_ARG_NULL, gfp);
     if (!pending)
         return NULL;
 


### PR DESCRIPTION
- Fix ksu_handle_sys_read signature to match kernel's extern declaration
- Define missing static keys: ksu_is_init_rc_hook_enabled, ksu_is_input_hook_enabled
- Define ksu_init_rc_hook_key_false, ksu_input_hook_key_false for ksud.c
- Define fake_state and ksu_selinux_hide_running for SELinux hooks
- Fix USER_ARG_NULL passing in sulog/event.c