### PR TITLE
Fix argument passing in ksu_sulog_capture call

### DIFF
--- a/kernel/sulog/event.c
+++ b/kernel/sulog/event.c
@@ -370,7 +370,7 @@ static struct ksu_sulog_pending_event *ksu_sulog_capture_grant_root(const struct
     // This is actually stupid fix
 #define USER_ARG_NULL ((struct user_arg_ptr){ 0 })
 
-    pending = ksu_sulog_capture(KSU_SULOG_EVENT_IOCTL_GRANT_ROOT, NULL, &USER_ARG_NULL, gfp);
+    pending = ksu_sulog_capture(KSU_SULOG_EVENT_IOCTL_GRANT_ROOT, NULL, USER_ARG_NULL, gfp);
     if (!pending)
         return NULL;
 


### PR DESCRIPTION
An extra "&" symbol caused a compilation error, we need to remove it.