### PR TITLE
Fix Superuser and Module lists being unreadable to TalkBack

### DIFF
--- a/manager/app/src/main/java/com/sukisu/ultra/ui/component/miuix/SuperSearchBar.kt
+++ b/manager/app/src/main/java/com/sukisu/ultra/ui/component/miuix/SuperSearchBar.kt
@@ -46,8 +46,6 @@ import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.layout
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.semantics.onClick
-import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
@@ -138,7 +136,6 @@ fun SearchStatus.SearchPager(
             .fillMaxSize()
             .zIndex(5f)
             .drawBehind { drawRect(surfaceColor.copy(alpha = surfaceAlpha)) }
-            .semantics { onClick { false } }
             .then(
                 if (!searchStatus.isCollapsed()) Modifier.pointerInput(Unit) { } else Modifier
             )


### PR DESCRIPTION
## Problem
With TalkBack on, the Superuser and Module tabs are unusable. Swiping through either list lands on a single "unlabeled" element that covers the whole screen, and none of the app/module rows can be reached or toggled. The Settings tab is unaffected.

## Cause
Both list screens mount the search overlay (`SearchStatus.SearchPager` in `SuperSearchBar.kt`) in the Scaffold `popupHost` slot; the Settings screen has an empty `popupHost`. The overlay's root `Column` is `fillMaxSize().zIndex(5f)` and carried `.semantics { onClick { false } }`. That `onClick` action makes the full-screen overlay a single clickable semantics node sitting on top of the list, so TalkBack only ever lands on that one node and the `LazyColumn` rows underneath never surface.

The action returns `false` (unhandled) and does nothing functional; clicks while the panel is open are already absorbed by the `pointerInput` on the next line.

## Fix
Drop `.semantics { onClick { false } }` from the overlay (and the now-unused `semantics`/`onClick` imports). The rows expose their own semantics again.

## Testing
Pixel 10 Pro XL, Android 17, SukiSU Ultra v4.1.3, Miuix UI. Inspected the accessibility tree with uiautomator:
- Before: Superuser and Module each expose one unlabeled, full-screen clickable node; no row nodes at all.
- After: every row exposes its app/module name, package, and ROOT/UMOUNT/CUSTOM tag, and the switches are operable nodes. Home is restored the same way.