### PR TITLE
kernel: fix spurious safe mode with CONFIG_KSU_SUSFS

### DIFF
--- a/kernel/runtime/ksud.c
+++ b/kernel/runtime/ksud.c
@@ -53,14 +53,7 @@ void on_post_fs_data(void)
     ksu_load_allow_list();
     ksu_observer_init();
     // sanity check, this may influence the performance
-#if defined(CONFIG_KSU_SUSFS) && defined(KSU_COMPAT_USE_STATIC_KEY)
-    if (static_key_enabled(&ksu_is_input_hook_enabled)) {
-        static_branch_disable(&ksu_is_input_hook_enabled);
-        pr_info("ksu_input_hook is disabled\n");
-    }
-#else
     stop_input_hook();
-#endif
     ksu_selinux_hide_handle_post_fs_data();
 }
 
@@ -575,14 +568,7 @@ bool ksu_is_safe_mode(void)
         return true;
 
     // stop hook first!
-#if defined(CONFIG_KSU_SUSFS) && defined(KSU_COMPAT_USE_STATIC_KEY)
-    if (static_key_enabled(&ksu_is_input_hook_enabled)) {
-        static_branch_disable(&ksu_is_input_hook_enabled);
-        pr_info("ksu_input_hook is disabled\n");
-    }
-#else
     stop_input_hook();
-#endif
 
     if (!safe_mode_flag)
         return false;
@@ -692,14 +678,30 @@ static struct input_handler vol_detector_handler = {
     .id_table = vol_detector_ids,
 };
 
+static bool vol_detector_registered = false;
+
 static int vol_detector_init()
 {
+    int ret;
+
     pr_info("vol_detector: init\n");
-    return input_register_handler(&vol_detector_handler);
+    ret = input_register_handler(&vol_detector_handler);
+    if (ret) {
+        pr_err("vol_detector: register failed: %d\n", ret);
+        return ret;
+    }
+
+    vol_detector_registered = true;
+    return 0;
 }
 
 static int vol_detector_exit(void)
 {
+    if (!vol_detector_registered) {
+        return 0;
+    }
+    vol_detector_registered = false;
+
     pr_info("vol_detector: exit\n");
     input_unregister_handler(&vol_detector_handler);
     return 0;
@@ -723,6 +725,14 @@ static void stop_input_hook(void)
         return;
     }
     ksu_input_hook = false;
+
+#if defined(CONFIG_KSU_SUSFS) && defined(KSU_COMPAT_USE_STATIC_KEY)
+    if (static_key_enabled(&ksu_is_input_hook_enabled)) {
+        static_branch_disable(&ksu_is_input_hook_enabled);
+        pr_info("ksu_input_hook is disabled\n");
+    }
+#endif
+
     pr_info("stop input_hook\n");
     vol_detector_exit();
 }


### PR DESCRIPTION
## Problem

With `CONFIG_KSU_SUSFS=y` the volume key handler is never unregistered and keeps counting presses for the whole session. Three presses at any point — hours or days after boot — silently enable safe mode ([#919](https://github.com/SukiSU-Ultra/SukiSU-Ultra/issues/919)):

```
[113484.357417] KernelSU: KEY_VOLUMEDOWN press detected!
[113484.357423] KernelSU: volume keys pressed max times, safe mode detected!
```

That is 31.5 h of uptime. The manager then shows the safe mode badge and hides the module install button, while loaded modules keep running — `disable_all_modules()` only runs at post-fs-data.

## Cause

`vol_detector_event()` is gated by nothing, yet both teardown sites — `on_post_fs_data()` and `ksu_is_safe_mode()` — only touch the now-vestigial static key:

```c
#if defined(CONFIG_KSU_SUSFS) && defined(KSU_COMPAT_USE_STATIC_KEY)
    static_branch_disable(&ksu_is_input_hook_enabled);
#else
    stop_input_hook();
#endif
```

`KSU_COMPAT_USE_STATIC_KEY` is set for >= 4.3, so this is effectively just `CONFIG_KSU_SUSFS`. It also breaks what `vol_detector_event()` states about itself: *"since unregging is done anyway on `ksu_is_safe_mode()` or `on_post_fs_data()` we just dont bother."*

## Fix

- Call `stop_input_hook()` unconditionally from both sites and move the static key teardown inside it — it is already idempotent via `if (!ksu_input_hook) return;`
- Both sites are process context (the ioctl dispatcher, and `ksu_handle_execveat()` — a direct hook, not a kprobe), so `input_unregister_handler()` is safe there
- Track registration state: `vol_detector_init()` ignored the `input_register_handler()` return value, which would now unregister a handler that was never linked

`main` already does the equivalent — `ksu_stop_input_hook_runtime()` runs from `ksu_is_safe_mode()` with no SUSFS condition.
