### PR TITLE
feat(kernel): Implement dynamic CPU hardware identity and vvar spoofing

### DIFF
--- a/kernel/Kbuild
+++ b/kernel/Kbuild
@@ -53,6 +53,8 @@ kernelsu-objs += feature/selinux_hide.o
 
 kernelsu-objs += feature/uts_spoof.o
 
+kernelsu-objs += feature/cpu_spoof.o
+
 ifdef KBUILD_EXTMOD
 ifeq ($(CONFIG_KSU_DISABLE_MANAGER),y)
 ccflags-y += -DCONFIG_KSU_DISABLE_MANAGER=1

--- a/kernel/feature/cpu_spoof.c
+++ b/kernel/feature/cpu_spoof.c
@@ -1,0 +1,184 @@
+// SPDX-License-Identifier: GPL-2.0
+#include <linux/kernel.h>
+#include <linux/types.h>
+#include <linux/cpumask.h>
+#include <linux/percpu.h>
+#include <linux/jiffies.h>
+#include <linux/delay.h>
+#include <linux/clocksource.h>
+#include <linux/errno.h>
+
+#include "cpu_spoof.h"
+#include "infra/symbol_resolver.h"
+#include "klog.h"
+
+#if defined(CONFIG_ARM64) || defined(__aarch64__)
+#include <asm/cpu.h>
+#include <asm/cputype.h>
+#include <asm/cpufeature.h>
+#include <vdso/datapage.h>
+#include <vdso/clocksource.h>
+
+#ifndef MIDR_PARTNUM_SHIFT
+#define MIDR_PARTNUM_SHIFT 4
+#endif
+
+#ifndef MIDR_PARTNUM_MASK
+#define MIDR_PARTNUM_MASK (0xfff << MIDR_PARTNUM_SHIFT)
+#endif
+
+#ifndef MIDR_PARTNUM
+#define MIDR_PARTNUM(midr) (((midr) & MIDR_PARTNUM_MASK) >> MIDR_PARTNUM_SHIFT)
+#endif
+
+#ifndef ARM_CPU_PART_NEOVERSE_N1
+#define ARM_CPU_PART_NEOVERSE_N1 0xd0c
+#endif
+
+#ifndef ARM_CPU_PART_CORTEX_A76
+#define ARM_CPU_PART_CORTEX_A76 0xd0b
+#endif
+
+#ifndef QCOM_CPU_PART_KRYO_4XX_GOLD
+#define QCOM_CPU_PART_KRYO_4XX_GOLD 0x804
+#endif
+
+#ifndef CS_HRES_COARSE
+#define CS_HRES_COARSE 0
+#endif
+
+#ifndef CS_RAW
+#define CS_RAW 1
+#endif
+
+#ifndef VDSO_CLOCKMODE_ARCHTIMER
+#define VDSO_CLOCKMODE_ARCHTIMER 1
+#endif
+
+#ifndef ARM64_WORKAROUND_1418040
+#define ARM64_WORKAROUND_1418040 37
+#endif
+
+#endif
+
+int ksu_set_spoof_cpu(const struct ksu_set_spoof_cpu_cmd *cmd)
+{
+    if (!cmd)
+        return -EINVAL;
+
+    /* Boundary Enforcement to prevent out-of-bounds per-CPU page dereferencing */
+    if (cmd->cpu_index >= num_possible_cpus()) {
+        pr_warn("ksu: set_spoof_cpu out-of-bounds cpu_index %u\n", cmd->cpu_index);
+        return -EINVAL;
+    }
+
+#if defined(CONFIG_ARM64) || defined(__aarch64__)
+    /* 1. Resolve 'cpu_data' and overwrite target core MIDR (executed for each CPU) */
+    {
+        unsigned long cpu_data_base = find_kernel_symbol_exact("cpu_data");
+        if (cpu_data_base) {
+            struct cpuinfo_arm64 *info = per_cpu_ptr((struct cpuinfo_arm64 *)cpu_data_base, cmd->cpu_index);
+            if (info) {
+                info->reg_midr = cmd->midr;
+            }
+        } else {
+            pr_warn("ksu: set_spoof_cpu failed to resolve 'cpu_data'\n");
+        }
+    }
+
+    /* 2. Global modifications (executed exactly once on CPU 0) */
+    if (cmd->cpu_index == 0) {
+        /* A. Override global dynamic timing metric */
+        unsigned long *lpj = (unsigned long *)find_kernel_symbol_exact("loops_per_jiffy");
+        if (lpj) {
+            pr_info("ksu: set_spoof_cpu current global loops_per_jiffy: %lu\n", *lpj);
+            *lpj = ((unsigned long)cmd->bogomips * 500000) / (100 * HZ);
+            pr_info("ksu: set_spoof_cpu updated global loops_per_jiffy: %lu\n", *lpj);
+        } else {
+            pr_warn("ksu: set_spoof_cpu failed to resolve 'loops_per_jiffy'\n");
+        }
+
+        /* B. Globally overwrite hardware capabilities */
+        unsigned long *elf_hwcap_bitmap = (unsigned long *)find_kernel_symbol_exact("elf_hwcap");
+        if (elf_hwcap_bitmap) {
+            pr_info("ksu: set_spoof_cpu current elf_hwcap: 0x%lx, elf_hwcap2: 0x%lx\n", elf_hwcap_bitmap[0],
+                    elf_hwcap_bitmap[1]);
+            elf_hwcap_bitmap[0] = cmd->hwcap; /* Primary hwcap */
+            elf_hwcap_bitmap[1] = cmd->hwcap2; /* Secondary hwcap2 (index 1 of the bitmap) */
+            pr_info("ksu: set_spoof_cpu updated elf_hwcap: 0x%lx, elf_hwcap2: 0x%lx\n", elf_hwcap_bitmap[0],
+                    elf_hwcap_bitmap[1]);
+        } else {
+            pr_warn("ksu: set_spoof_cpu failed to resolve 'elf_hwcap'\n");
+        }
+
+        /* C. Erratum Reversal and Clock Mode Alignment (Clean Cores Only) */
+        {
+            unsigned int part = MIDR_PARTNUM(cmd->midr);
+            if (part != ARM_CPU_PART_NEOVERSE_N1 && part != ARM_CPU_PART_CORTEX_A76 &&
+                part != QCOM_CPU_PART_KRYO_4XX_GOLD) {
+                /* Resolve 'vdso_data' double pointer and align clock mode */
+                struct vdso_data **vdso_data_ptr = (struct vdso_data **)find_kernel_symbol_exact("vdso_data");
+                if (vdso_data_ptr && *vdso_data_ptr) {
+                    struct vdso_data *vdso = *vdso_data_ptr;
+                    pr_info("ksu: set_spoof_cpu found 'vdso_data' (current CS_HRES_COARSE clock_mode: %d)\n",
+                            vdso[CS_HRES_COARSE].clock_mode);
+                    vdso[CS_HRES_COARSE].clock_mode = VDSO_CLOCKMODE_ARCHTIMER;
+                    vdso[CS_RAW].clock_mode = VDSO_CLOCKMODE_ARCHTIMER;
+                    pr_info("ksu: set_spoof_cpu updated 'vdso_data' clock_mode to %d\n",
+                            vdso[CS_HRES_COARSE].clock_mode);
+                } else {
+                    pr_warn("ksu: set_spoof_cpu failed to resolve 'vdso_data'\n");
+                }
+
+                /* Resolve 'curr_clocksource' double pointer and overwrite active clock mode */
+                {
+                    struct clocksource **curr_cs_ptr =
+                        (struct clocksource **)find_kernel_symbol_exact("curr_clocksource");
+                    if (curr_cs_ptr && *curr_cs_ptr) {
+                        struct clocksource *cs = *curr_cs_ptr;
+                        pr_info("ksu: set_spoof_cpu found active clocksource '%s' (current vdso_clock_mode: %d)\n",
+                                cs->name ? cs->name : "unknown", cs->vdso_clock_mode);
+                        cs->vdso_clock_mode = VDSO_CLOCKMODE_ARCHTIMER;
+                        pr_info("ksu: set_spoof_cpu updated clocksource '%s' vdso_clock_mode to %d\n",
+                                cs->name ? cs->name : "unknown", cs->vdso_clock_mode);
+                    } else {
+                        pr_warn("ksu: set_spoof_cpu failed to resolve 'curr_clocksource'\n");
+                    }
+                }
+
+                /* Overwrite fallback default clock mode variable */
+                {
+                    enum vdso_clock_mode *vd_default = (enum vdso_clock_mode *)find_kernel_symbol_exact("vdso_default");
+                    if (vd_default) {
+                        pr_info("ksu: set_spoof_cpu found 'vdso_default' (current value: %d)\n", *vd_default);
+                        *vd_default = VDSO_CLOCKMODE_ARCHTIMER;
+                        pr_info("ksu: set_spoof_cpu updated 'vdso_default' to %d\n", *vd_default);
+                    } else {
+                        pr_warn("ksu: set_spoof_cpu failed to resolve 'vdso_default'\n");
+                    }
+                }
+
+                /* Resolve and clear capability bitmap (handles cpu_hwcaps / system_cpucaps fallback) */
+                {
+                    unsigned long *caps = (unsigned long *)find_kernel_symbol_exact("cpu_hwcaps");
+                    if (!caps) {
+                        caps = (unsigned long *)find_kernel_symbol_exact("system_cpucaps");
+                    }
+                    if (caps) {
+                        pr_info("ksu: set_spoof_cpu current ARM64_WORKAROUND_1418040 capability state: %d\n",
+                                test_bit(ARM64_WORKAROUND_1418040, caps));
+                        clear_bit(ARM64_WORKAROUND_1418040, caps);
+                        pr_info("ksu: set_spoof_cpu updated ARM64_WORKAROUND_1418040 capability state: %d\n",
+                                test_bit(ARM64_WORKAROUND_1418040, caps));
+                    } else {
+                        pr_warn("ksu: set_spoof_cpu failed to resolve 'cpu_hwcaps' or 'system_cpucaps'\n");
+                    }
+                }
+            }
+        }
+    }
+#endif
+
+    pr_info("KernelSU Stealth: CPU %u identity spoofed (MIDR: 0x%08x)\n", cmd->cpu_index, cmd->midr);
+    return 0;
+}

--- a/kernel/feature/cpu_spoof.h
+++ b/kernel/feature/cpu_spoof.h
@@ -1,0 +1,9 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+#ifndef __KSU_H_CPU_SPOOF
+#define __KSU_H_CPU_SPOOF
+
+#include "uapi/supercall.h"
+
+int ksu_set_spoof_cpu(const struct ksu_set_spoof_cpu_cmd *cmd);
+
+#endif /* __KSU_H_CPU_SPOOF */

--- a/kernel/supercall/dispatch.c
+++ b/kernel/supercall/dispatch.c
@@ -23,6 +23,7 @@
 #include "sulog/fd.h"
 #include "supercall/supercall.h"
 #include "feature/uts_spoof.h"
+#include "feature/cpu_spoof.h"
 
 #ifdef CONFIG_KPM
 #include "kpm/kpm.h"
@@ -709,6 +710,17 @@ static int do_set_spoof_version(void __user *arg)
                                  cmd.version[0] != '\0' ? cmd.version : NULL);
 }
 
+static int do_set_spoof_cpu(void __user *arg)
+{
+    struct ksu_set_spoof_cpu_cmd cmd;
+
+    if (copy_from_user(&cmd, arg, sizeof(cmd))) {
+        return -EFAULT;
+    }
+
+    return ksu_set_spoof_cpu(&cmd);
+}
+
 static int list_try_umount(void __user *arg)
 {
     struct ksu_list_try_umount_cmd cmd;
@@ -1004,6 +1016,12 @@ static const struct ksu_ioctl_cmd_map ksu_ioctl_handlers[] = {
         .cmd = KSU_IOCTL_SET_SPOOF_VERSION,
         .name = "SET_SPOOF_VERSION",
         .handler = do_set_spoof_version,
+        .perm_check = only_root
+    },
+    {
+        .cmd = KSU_IOCTL_SET_SPOOF_CPU,
+        .name = "SET_SPOOF_CPU",
+        .handler = do_set_spoof_cpu,
         .perm_check = only_root
     },
     { 

--- a/uapi/supercall.h
+++ b/uapi/supercall.h
@@ -150,6 +150,14 @@ struct ksu_set_spoof_version_cmd {
     __u8 version[65]; /* Input: e.g., "#1 SMP PREEMPT Thu Jan 1 00:00:00 UTC 2026" */
 };
 
+struct ksu_set_spoof_cpu_cmd {
+    __u32 cpu_index;  /* Target processor core index */
+    __u32 midr;       /* Main ID Register payload */
+    __u32 bogomips;   /* BogoMIPS performance timing metric */
+    __u64 hwcap;      /* Main ELF Hardware Capabilities mask */
+    __u64 hwcap2;     /* Auxiliary ELF Hardware Capabilities mask */
+};
+
 // List current umount entries
 struct ksu_list_try_umount_cmd {
     __aligned_u64 arg; // User buffer
@@ -222,6 +230,7 @@ static const __u32 KSU_IOCTL_HOOK_TYPE = _IOC(_IOC_READ, 'K', 101, 0);
 static const __u32 KSU_IOCTL_ENABLE_KPM = _IOC(_IOC_READ, 'K', 102, 0);
 static const __u32 KSU_IOCTL_LIST_TRY_UMOUNT = _IOC(_IOC_READ | _IOC_WRITE, 'K', 103, 0);
 static const __u32 KSU_IOCTL_SET_SPOOF_VERSION = _IOC(_IOC_WRITE, 'K', 104, 0);
+static const __u32 KSU_IOCTL_SET_SPOOF_CPU = _IOC(_IOC_WRITE, 'K', 105, 0);
 static const __u32 KSU_IOCTL_KPM = _IOC(_IOC_READ | _IOC_WRITE, 'K', 200, 0);
 
 #endif


### PR DESCRIPTION
## Summary

Introduces a dynamic kernel-level spoofing mechanism to alter CPU identity, hardware capabilities, and vDSO (vvar) configuration at runtime via `KSU_IOCTL_SET_SPOOF_CPU`.

Original implementation by @JingMatrix (from JingMatrix/KernelSU).

## Changes

- **`kernel/feature/cpu_spoof.{c,h}`**:
  - Overwrites `reg_midr` for target core via per-CPU `cpu_data`.
  - Overwrites global BogoMIPS metric `loops_per_jiffy` on CPU 0.
  - Overwrites `elf_hwcap` and `elf_hwcap2` bitmasks.
  - Clears ARM Erratum 1418040 workaround state (`ARM64_WORKAROUND_1418040`) and restores VDSO clock mode to `VDSO_CLOCKMODE_ARCHTIMER`.
- **`uapi/supercall.h`**: Adds `struct ksu_set_spoof_cpu_cmd` and `KSU_IOCTL_SET_SPOOF_CPU`.
- **`kernel/supercall/dispatch.c`**: Adds `do_set_spoof_cpu` handler gated by `only_root`.

## Credits

- **Author / Idea**: @JingMatrix (`JingMatrix <jingmatrix@gmail.com>`)