### PR TITLE
feat(manager): identify Zygisk implementation and display status (#927)

### DIFF
--- a/manager/app/src/main/java/com/sukisu/ultra/data/model/Module.kt
+++ b/manager/app/src/main/java/com/sukisu/ultra/data/model/Module.kt
@@ -17,6 +17,7 @@ data class Module(
     val hasWebUi: Boolean,
     val hasActionScript: Boolean,
     val metamodule: Boolean,
+    val zygisk: Boolean = false,
     val actionIconPath: String?,
     val webUiIconPath: String?,
 )

--- a/manager/app/src/main/java/com/sukisu/ultra/data/model/RepoModule.kt
+++ b/manager/app/src/main/java/com/sukisu/ultra/data/model/RepoModule.kt
@@ -23,6 +23,7 @@ data class RepoModule(
     val authorList: List<Author>,
     val summary: String,
     val metamodule: Boolean,
+    val zygisk: Boolean = false,
     val stargazerCount: Int,
     val updatedAt: String,
     val createdAt: String,

--- a/manager/app/src/main/java/com/sukisu/ultra/data/repository/ModuleRepoRepositoryImpl.kt
+++ b/manager/app/src/main/java/com/sukisu/ultra/data/repository/ModuleRepoRepositoryImpl.kt
@@ -61,6 +61,7 @@ class ModuleRepoRepositoryImpl : ModuleRepoRepository {
         val authors = if (authorList.isNotEmpty()) authorList.joinToString(", ") { it.name } else item.optString("authors", "")
         val summary = item.optString("summary", "")
         val metamodule = item.optBoolean("metamodule", false)
+        val zygisk = item.optBoolean("zygisk", false)
         val stargazerCount = item.optInt("stargazerCount", 0)
         val updatedAt = item.optString("updatedAt", "")
         val createdAt = item.optString("createdAt", "")
@@ -98,6 +99,7 @@ class ModuleRepoRepositoryImpl : ModuleRepoRepository {
             authorList = authorList,
             summary = summary,
             metamodule = metamodule,
+            zygisk = zygisk,
             stargazerCount = stargazerCount,
             updatedAt = updatedAt,
             createdAt = createdAt,

--- a/manager/app/src/main/java/com/sukisu/ultra/data/repository/ModuleRepositoryImpl.kt
+++ b/manager/app/src/main/java/com/sukisu/ultra/data/repository/ModuleRepositoryImpl.kt
@@ -40,6 +40,7 @@ class ModuleRepositoryImpl : ModuleRepository {
                         hasWebUi = obj.optBoolean("web"),
                         hasActionScript = obj.optBoolean("action"),
                         metamodule = (obj.optInt("metamodule") != 0) || obj.optBoolean("metamodule"),
+                        zygisk = (obj.optInt("zygisk") != 0) || obj.optBoolean("zygisk"),
                         actionIconPath = obj.optString("actionIcon").takeIf { it.isNotBlank() },
                         webUiIconPath = obj.optString("webuiIcon").takeIf { it.isNotBlank() }
                     )

--- a/manager/app/src/main/java/com/sukisu/ultra/ui/screen/home/HomeMaterial.kt
+++ b/manager/app/src/main/java/com/sukisu/ultra/ui/screen/home/HomeMaterial.kt
@@ -433,6 +433,13 @@ private fun InfoCard(systemInfo: SystemInfo, showFullStatus: Boolean = true) {
                         hookTypeLabel
                     )
                 }
+                if (!systemInfo.zygiskImplementation.isNullOrBlank()) {
+                    Spacer(Modifier.height(16.dp))
+                    InfoCardItem(
+                        stringResource(R.string.home_zygisk_implementation),
+                        systemInfo.zygiskImplementation
+                    )
+                }
 
             }
             Spacer(Modifier.height(16.dp))

--- a/manager/app/src/main/java/com/sukisu/ultra/ui/screen/home/HomeMiuix.kt
+++ b/manager/app/src/main/java/com/sukisu/ultra/ui/screen/home/HomeMiuix.kt
@@ -495,6 +495,12 @@ private fun InfoCard(systemInfo: SystemInfo, showFullStatus: Boolean = true) {
                 } else if (!hookTypeLabel.isNullOrBlank()) {
                     InfoText(title = stringResource(R.string.hook_type), content = hookTypeLabel)
                 }
+                if (!systemInfo.zygiskImplementation.isNullOrBlank()) {
+                    InfoText(
+                        title = stringResource(R.string.home_zygisk_implementation),
+                        content = systemInfo.zygiskImplementation
+                    )
+                }
 
             }
 

--- a/manager/app/src/main/java/com/sukisu/ultra/ui/screen/home/HomeUtils.kt
+++ b/manager/app/src/main/java/com/sukisu/ultra/ui/screen/home/HomeUtils.kt
@@ -24,8 +24,60 @@ data class SystemInfo(
     val kernelFullVersion: String?,
     val fingerprint: String,
     val selinuxStatus: String,
-    val seccompStatus: Int
+    val seccompStatus: Int,
+    val zygiskImplementation: String? = null,
 )
+
+fun getZygiskImplementation(
+    notInstalledText: String,
+    disabledText: String,
+    rebootRequiredText: String,
+): String {
+    return runCatching {
+        val modulesJson = com.sukisu.ultra.ui.util.listModules()
+        val array = org.json.JSONArray(modulesJson)
+        val providers = mutableListOf<org.json.JSONObject>()
+        for (i in 0 until array.length()) {
+            val obj = array.getJSONObject(i)
+            val isProvider = (obj.optInt("zygisk_provider") != 0) || obj.optBoolean("zygisk_provider")
+            if (isProvider) {
+                providers.add(obj)
+            }
+        }
+
+        if (providers.isEmpty()) {
+            return notInstalledText
+        }
+
+        // 1. Check if any provider's daemon is actively running
+        val runningProvider = providers.firstOrNull {
+            (it.optInt("zygisk_running") != 0) || it.optBoolean("zygisk_running")
+        }
+        if (runningProvider != null) {
+            val name = runningProvider.optString("name").takeIf { it.isNotBlank() }
+                ?: runningProvider.getString("id")
+            val version = runningProvider.optString("version").takeIf { it.isNotBlank() }
+            return listOfNotNull(name, version).joinToString(" ")
+        }
+
+        // 2. If none is running, check enabled status
+        val enabledProviders = providers.filter {
+            it.optBoolean("enabled", false) && !it.optBoolean("remove", false)
+        }
+        if (enabledProviders.isNotEmpty()) {
+            val names = enabledProviders.joinToString(", ") {
+                it.optString("name").takeIf { name -> name.isNotBlank() } ?: it.getString("id")
+            }
+            return "$names ($rebootRequiredText)"
+        }
+
+        // 3. All installed providers are disabled
+        val names = providers.joinToString(", ") {
+            it.optString("name").takeIf { name -> name.isNotBlank() } ?: it.getString("id")
+        }
+        return "$names ($disabledText)"
+    }.getOrDefault(notInstalledText)
+}
 
 
 fun getManagerVersion(context: Context): ManagerVersion {

--- a/manager/app/src/main/java/com/sukisu/ultra/ui/screen/module/ModuleMaterial.kt
+++ b/manager/app/src/main/java/com/sukisu/ultra/ui/screen/module/ModuleMaterial.kt
@@ -828,14 +828,27 @@ private fun ModuleItem(
                 }
             )
 
-            Row(modifier = Modifier.padding(vertical = 4.dp)) {
-                if (module.metamodule) {
-                    StatusTag(
-                        "META",
-                        modifier = Modifier.padding(bottom = 4.dp),
-                        contentColor = MaterialTheme.colorScheme.onPrimary,
-                        backgroundColor = MaterialTheme.colorScheme.primary
-                    )
+            if (module.metamodule || module.zygisk) {
+                Row(
+                    modifier = Modifier.padding(vertical = 4.dp),
+                    horizontalArrangement = Arrangement.spacedBy(6.dp)
+                ) {
+                    if (module.metamodule) {
+                        StatusTag(
+                            "META",
+                            modifier = Modifier.padding(bottom = 4.dp),
+                            contentColor = MaterialTheme.colorScheme.onPrimary,
+                            backgroundColor = MaterialTheme.colorScheme.primary
+                        )
+                    }
+                    if (module.zygisk) {
+                        StatusTag(
+                            "ZYGISK",
+                            modifier = Modifier.padding(bottom = 4.dp),
+                            contentColor = MaterialTheme.colorScheme.onTertiaryContainer,
+                            backgroundColor = MaterialTheme.colorScheme.tertiaryContainer
+                        )
+                    }
                 }
             }
 

--- a/manager/app/src/main/java/com/sukisu/ultra/ui/screen/module/ModuleMiuix.kt
+++ b/manager/app/src/main/java/com/sukisu/ultra/ui/screen/module/ModuleMiuix.kt
@@ -851,24 +851,45 @@ fun ModuleItem(
                 SubcomposeLayout { constraints ->
                     val spacingPx = 6.dp.roundToPx()
                     var nameTextLayout: TextLayoutResult? = null
-                    val metaPlaceable = if (module.metamodule) {
-                        subcompose("meta") {
-                            Text(
-                                text = "META",
-                                fontSize = 12.sp,
-                                color = updateTint,
-                                modifier = Modifier
-                                    .clip(RoundedCornerShape(6.dp))
-                                    .background(updateBg)
-                                    .padding(horizontal = 6.dp, vertical = 2.dp),
-                                fontWeight = FontWeight(750),
-                                maxLines = 1,
-                                softWrap = false
-                            )
+                    val tagsPlaceable = if (module.metamodule || module.zygisk) {
+                        subcompose("tags") {
+                            Row(
+                                horizontalArrangement = Arrangement.spacedBy(4.dp),
+                                verticalAlignment = Alignment.CenterVertically
+                            ) {
+                                if (module.metamodule) {
+                                    Text(
+                                        text = "META",
+                                        fontSize = 12.sp,
+                                        color = updateTint,
+                                        modifier = Modifier
+                                            .clip(RoundedCornerShape(6.dp))
+                                            .background(updateBg)
+                                            .padding(horizontal = 6.dp, vertical = 2.dp),
+                                        fontWeight = FontWeight(750),
+                                        maxLines = 1,
+                                        softWrap = false
+                                    )
+                                }
+                                if (module.zygisk) {
+                                    Text(
+                                        text = "ZYGISK",
+                                        fontSize = 12.sp,
+                                        color = updateTint,
+                                        modifier = Modifier
+                                            .clip(RoundedCornerShape(6.dp))
+                                            .background(updateBg)
+                                            .padding(horizontal = 6.dp, vertical = 2.dp),
+                                        fontWeight = FontWeight(750),
+                                        maxLines = 1,
+                                        softWrap = false
+                                    )
+                                }
+                            }
                         }.first().measure(Constraints(0, constraints.maxWidth, 0, constraints.maxHeight))
                     } else null
 
-                    val reserved = (metaPlaceable?.width ?: 0) + if (metaPlaceable != null) spacingPx else 0
+                    val reserved = (tagsPlaceable?.width ?: 0) + if (tagsPlaceable != null) spacingPx else 0
                     val nameMax = (constraints.maxWidth - reserved).coerceAtLeast(0)
                     val namePlaceable = subcompose("name") {
                         Text(
@@ -882,7 +903,7 @@ fun ModuleItem(
                     }.first().measure(Constraints(constraints.minWidth, nameMax, constraints.minHeight, constraints.maxHeight))
 
                     val width = (namePlaceable.width + reserved).coerceIn(constraints.minWidth, constraints.maxWidth)
-                    val height = maxOf(namePlaceable.height, metaPlaceable?.height ?: 0)
+                    val height = maxOf(namePlaceable.height, tagsPlaceable?.height ?: 0)
 
                     layout(width, height) {
                         namePlaceable.placeRelative(0, 0)
@@ -890,7 +911,7 @@ fun ModuleItem(
                             val last = (layoutRes.lineCount - 1).coerceAtLeast(0)
                             layoutRes.getLineRight(last).toInt()
                         } ?: namePlaceable.width
-                        metaPlaceable?.placeRelative(endX + spacingPx, (height - (metaPlaceable.height)) / 2)
+                        tagsPlaceable?.placeRelative(endX + spacingPx, (height - (tagsPlaceable.height)) / 2)
                     }
                 }
                 Text(

--- a/manager/app/src/main/java/com/sukisu/ultra/ui/screen/modulerepo/ModuleRepoMaterial.kt
+++ b/manager/app/src/main/java/com/sukisu/ultra/ui/screen/modulerepo/ModuleRepoMaterial.kt
@@ -335,13 +335,25 @@ private fun RepoModuleList(
                         )
                     }
 
-                    Row(modifier = Modifier.padding(vertical = 4.dp)) {
-                        if (module.metamodule) {
-                            StatusTag(
-                                "META",
-                                contentColor = MaterialTheme.colorScheme.onPrimary,
-                                backgroundColor = MaterialTheme.colorScheme.primary
-                            )
+                    if (module.metamodule || module.zygisk) {
+                        Row(
+                            modifier = Modifier.padding(vertical = 4.dp),
+                            horizontalArrangement = Arrangement.spacedBy(6.dp)
+                        ) {
+                            if (module.metamodule) {
+                                StatusTag(
+                                    "META",
+                                    contentColor = MaterialTheme.colorScheme.onPrimary,
+                                    backgroundColor = MaterialTheme.colorScheme.primary
+                                )
+                            }
+                            if (module.zygisk) {
+                                StatusTag(
+                                    "ZYGISK",
+                                    contentColor = MaterialTheme.colorScheme.onTertiaryContainer,
+                                    backgroundColor = MaterialTheme.colorScheme.tertiaryContainer
+                                )
+                            }
                         }
                     }
                     HorizontalDivider(thickness = Dp.Hairline)

--- a/manager/app/src/main/java/com/sukisu/ultra/ui/screen/modulerepo/ModuleRepoMiuix.kt
+++ b/manager/app/src/main/java/com/sukisu/ultra/ui/screen/modulerepo/ModuleRepoMiuix.kt
@@ -294,6 +294,20 @@ fun ModuleRepoScreenMiuix(
                                                 maxLines = 1
                                             )
                                         }
+                                        if (module.zygisk) {
+                                            Text(
+                                                text = "ZYGISK",
+                                                fontSize = 12.sp,
+                                                color = metaTint,
+                                                modifier = Modifier
+                                                    .padding(start = 6.dp)
+                                                    .clip(RoundedCornerShape(6.dp))
+                                                    .background(metaBg)
+                                                    .padding(horizontal = 6.dp, vertical = 2.dp),
+                                                fontWeight = FontWeight(750),
+                                                maxLines = 1
+                                            )
+                                        }
                                         Spacer(Modifier.weight(1f))
                                         if (module.stargazerCount > 0) {
                                             Row(verticalAlignment = Alignment.CenterVertically) {
@@ -453,6 +467,20 @@ fun ModuleRepoScreenMiuix(
                                                 if (module.metamodule) {
                                                     Text(
                                                         text = "META",
+                                                        fontSize = 12.sp,
+                                                        color = metaTint,
+                                                        modifier = Modifier
+                                                            .padding(start = 6.dp)
+                                                            .clip(RoundedCornerShape(6.dp))
+                                                            .background(metaBg)
+                                                            .padding(horizontal = 6.dp, vertical = 2.dp),
+                                                        fontWeight = FontWeight(750),
+                                                        maxLines = 1
+                                                    )
+                                                }
+                                                if (module.zygisk) {
+                                                    Text(
+                                                        text = "ZYGISK",
                                                         fontSize = 12.sp,
                                                         color = metaTint,
                                                         modifier = Modifier

--- a/manager/app/src/main/java/com/sukisu/ultra/ui/viewmodel/HomeViewModel.kt
+++ b/manager/app/src/main/java/com/sukisu/ultra/ui/viewmodel/HomeViewModel.kt
@@ -56,6 +56,14 @@ class HomeViewModel(
         val managerVersion = getManagerVersion(ksuApp)
         val kernelFullVersion = if (isManager) Natives.getFullVersion() else null
 
+        val zygiskImplementation = if (isManager && isRootAvailable) {
+            com.sukisu.ultra.ui.screen.home.getZygiskImplementation(
+                notInstalledText = ksuApp.getString(com.sukisu.ultra.R.string.home_zygisk_not_installed),
+                disabledText = ksuApp.getString(com.sukisu.ultra.R.string.home_zygisk_disabled),
+                rebootRequiredText = ksuApp.getString(com.sukisu.ultra.R.string.home_zygisk_reboot_required),
+            )
+        } else null
+
         return HomeUiState(
             kernelVersion = kernelVersion,
             ksuVersion = ksuVersion,
@@ -85,6 +93,7 @@ class HomeViewModel(
                 seccompStatus = runCatching {
                     Os.prctl(21 /* PR_GET_SECCOMP */, 0, 0, 0, 0)
                 }.getOrDefault(-1),
+                zygiskImplementation = zygiskImplementation,
             ),
         )
     }

--- a/manager/app/src/main/res/values-zh-rCN/strings.xml
+++ b/manager/app/src/main/res/values-zh-rCN/strings.xml
@@ -625,4 +625,8 @@
     <string name="home_kernel_full_version">内核完整版本</string>
     <string name="settings_show_fullstatus">显示完整状态</string>
     <string name="settings_show_fullstatus_summary">在首页信息卡中显示设备的完整状态</string>
+    <string name="home_zygisk_implementation">Zygisk 实现</string>
+    <string name="home_zygisk_not_installed">未安装</string>
+    <string name="home_zygisk_disabled">已禁用</string>
+    <string name="home_zygisk_reboot_required">需要重启</string>
 </resources>

--- a/manager/app/src/main/res/values-zh-rTW/strings.xml
+++ b/manager/app/src/main/res/values-zh-rTW/strings.xml
@@ -623,4 +623,8 @@
     <string name="sort_by_update_time">更新時間</string>
     <string name="sort_reverse">倒序</string>
     <string name="uapi_mismatch">管理器 uapi 版本 (%1$d) 與 KernelSU 驅動 uapi 版本 (%2$d) 不匹配。</string>
+    <string name="home_zygisk_implementation">Zygisk 實作</string>
+    <string name="home_zygisk_not_installed">未安裝</string>
+    <string name="home_zygisk_disabled">已停用</string>
+    <string name="home_zygisk_reboot_required">需要重啟</string>
 </resources>

--- a/manager/app/src/main/res/values/strings.xml
+++ b/manager/app/src/main/res/values/strings.xml
@@ -637,4 +637,8 @@
     <string name="home_kernel_full_version">Kernel full version</string>
     <string name="settings_show_fullstatus">Show FullStatus</string>
     <string name="settings_show_fullstatus_summary">Display device FullStatus in home page info card</string>
+    <string name="home_zygisk_implementation">Zygisk implementation</string>
+    <string name="home_zygisk_not_installed">Not installed</string>
+    <string name="home_zygisk_disabled">Disabled</string>
+    <string name="home_zygisk_reboot_required">Reboot required</string>
 </resources>

--- a/userspace/ksud/src/defs.rs
+++ b/userspace/ksud/src/defs.rs
@@ -31,6 +31,7 @@ mod android {
 
     pub const MODULE_WEB_DIR: &str = "webroot";
     pub const MODULE_ACTION_SH: &str = "action.sh";
+    pub const MODULE_ZYGISK_DIR: &str = "zygisk";
     pub const DISABLE_FILE_NAME: &str = "disable";
     pub const UPDATE_FILE_NAME: &str = "update";
     pub const REMOVE_FILE_NAME: &str = "remove";

--- a/userspace/ksud/src/module.rs
+++ b/userspace/ksud/src/module.rs
@@ -1036,6 +1036,59 @@ fn resolve_module_icon_path(
     }
 }
 
+/// Check if module has a zygisk shared library (client module) matching NeoZygisk load_modules behavior
+pub fn has_zygisk_library(path: &Path) -> bool {
+    let zygisk_dir = path.join(defs::MODULE_ZYGISK_DIR);
+    if zygisk_dir.is_dir() {
+        if let Ok(entries) = std::fs::read_dir(&zygisk_dir) {
+            for entry in entries.flatten() {
+                let p = entry.path();
+                if p.extension().is_some_and(|ext| ext == "so") {
+                    return true;
+                }
+            }
+        }
+        return true;
+    }
+    false
+}
+
+/// Determine whether the provided module is a Zygisk implementation / provider
+pub fn is_zygisk_provider(module_id: &str) -> bool {
+    let id_lower = module_id.to_ascii_lowercase();
+    matches!(id_lower.as_str(), "zygisksu" | "rezygisk")
+}
+
+/// Check whether a process with the given name is running in /proc
+pub fn is_process_running(proc_name: &str) -> bool {
+    let Ok(entries) = std::fs::read_dir("/proc") else {
+        return false;
+    };
+    for entry in entries.flatten() {
+        let file_name = entry.file_name();
+        let file_str = file_name.to_string_lossy();
+        if file_str.chars().all(|c| c.is_ascii_digit()) {
+            let comm_path = entry.path().join("comm");
+            if let Ok(comm) = std::fs::read_to_string(&comm_path)
+                && comm.trim() == proc_name
+            {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+/// Determine whether the Zygisk provider's daemon is actually running
+pub fn is_zygisk_daemon_running(module_id: &str) -> bool {
+    let id_lower = module_id.to_ascii_lowercase();
+    match id_lower.as_str() {
+        "rezygisk" => is_process_running("rezygisk") || is_process_running("rezygiskd"),
+        "zygisksu" => is_process_running("zygiskd") || is_process_running("zygisk-companion"),
+        _ => false,
+    }
+}
+
 fn list_module(path: &str) -> Vec<HashMap<String, String>> {
     // Load all module configs once to minimize I/O overhead
     let all_configs = match crate::module_config::get_all_module_configs() {
@@ -1081,12 +1134,23 @@ fn list_module(path: &str) -> Vec<HashMap<String, String>> {
             }
         }
 
-        // Add enabled, update, remove, web, action flags
+        // Add enabled, update, remove, web, action, zygisk flags
         let enabled = !path.join(defs::DISABLE_FILE_NAME).exists();
         let update = path.join(defs::UPDATE_FILE_NAME).exists();
         let remove = path.join(defs::REMOVE_FILE_NAME).exists();
         let web = path.join(defs::MODULE_WEB_DIR).exists();
         let action = path.join(defs::MODULE_ACTION_SH).exists();
+        let is_provider = module_prop_map
+            .get("id")
+            .is_some_and(|id| is_zygisk_provider(id));
+        let zygisk_module = is_provider || has_zygisk_library(&path);
+        let zygisk_running = if is_provider {
+            module_prop_map
+                .get("id")
+                .is_some_and(|id| is_zygisk_daemon_running(id))
+        } else {
+            false
+        };
         let need_mount = path.join("system").exists() && !path.join("skip_mount").exists();
 
         module_prop_map.insert("enabled".to_owned(), enabled.to_string());
@@ -1094,6 +1158,9 @@ fn list_module(path: &str) -> Vec<HashMap<String, String>> {
         module_prop_map.insert("remove".to_owned(), remove.to_string());
         module_prop_map.insert("web".to_owned(), web.to_string());
         module_prop_map.insert("action".to_owned(), action.to_string());
+        module_prop_map.insert("zygisk".to_owned(), zygisk_module.to_string());
+        module_prop_map.insert("zygisk_provider".to_owned(), is_provider.to_string());
+        module_prop_map.insert("zygisk_running".to_owned(), zygisk_running.to_string());
         module_prop_map.insert("mount".to_owned(), need_mount.to_string());
 
         resolve_module_icon_path(&mut module_prop_map, "actionIcon", &path);


### PR DESCRIPTION
Closes #927

### Summary
This PR adds support for accurately identifying **Zygisk Implementation / Provider modules** (such as Zygisk Next, NeoZygisk, ReZygisk) and displaying the Zygisk environment status across the **Module List** and the **Home Screen**.

---

### Technical Background & Design
In the KernelSU ecosystem, Zygisk is provided as a standalone host module rather than built into the kernel/manager.
- **Provider Identification**: Standard Zygisk implementations universally use module IDs `zygisksu` (Zygisk Next, NeoZygisk, Shiroko) or `rezygisk` (ReZygisk).
- **Runtime Verification**: Zygisk host daemons (e.g. [NeoZygisk `zygiskd`](https://github.com/JingMatrix/NeoZygisk/blob/master/zygiskd/src/zygiskd.rs#L219-L258)) run dedicated background processes (`zygiskd`, `rezygisk`, `zygisk-companion`) to scan and load client modules (`zygisk/{arch}.so`). Checking process state via `/proc` ensures the manager reflects whether Zygisk is actually active versus merely marked as enabled.

---

### Key Changes

1. **`ksud` Userspace Daemon (`userspace/ksud/src/module.rs`)**:
   - `is_zygisk_provider`: Specifically identifies Zygisk host providers matching IDs `zygisksu` and `rezygisk`.
   - `is_zygisk_daemon_running`: Checks `/proc/<pid>/comm` for running host daemons (`zygiskd`, `zygisk-companion`, `rezygisk`, `rezygiskd`).
   - Exports `zygisk` (is provider) and `zygisk_running` (is daemon active) in the `ksud module list` JSON payload.

2. **Manager Home Screen (`HomeViewModel`, `HomeUtils`, `HomeMaterial`, `HomeMiuix`)**:
   - Asynchronously resolves Zygisk implementation status on `Dispatchers.IO` (zero UI blocking/ANR risk):
     - **Running**: Displays active implementation name and version (e.g., `Zygisk Next v1.2.0 (345)`, `ReZygisk v1.0.0`).
     - **Multiple Providers Installed**: Resolves and prioritizes the actively running provider daemon.
     - **Enabled but Not Running**: Displays `(Reboot required)` to prevent misleading users before a reboot.
     - **Disabled**: Displays `(Disabled)`.
     - **Not Installed**: Displays `Not installed`.
   - Localized strings added for EN, zh-CN, and zh-TW.
   - Rendered seamlessly in both **Material** and **Miuix** interfaces.

3. **Manager Module List (`ModuleMaterial`, `ModuleMiuix`)**:
   - Displays `ZYGISK` status badge on Zygisk provider modules (matching the existing `META` tag styling and behavior).

---

### Verification
- [x] Rust Clippy & Rustfmt checks passed with zero warnings.
- [x] All LKM, ksud, and Manager Android builds compiled and repacked successfully in CI.
