### PR TITLE
fix(ksud): broaden Zygisk daemon detection & restrict ZYGISK tag to providers

### DIFF
--- a/userspace/ksud/src/module.rs
+++ b/userspace/ksud/src/module.rs
@@ -1056,11 +1056,17 @@ pub fn has_zygisk_library(path: &Path) -> bool {
 /// Determine whether the provided module is a Zygisk implementation / provider
 pub fn is_zygisk_provider(module_id: &str) -> bool {
     let id_lower = module_id.to_ascii_lowercase();
-    matches!(id_lower.as_str(), "zygisksu" | "rezygisk")
+    matches!(
+        id_lower.as_str(),
+        "zygisksu" | "rezygisk" | "nyazygisk" | "neozygisk"
+    )
 }
 
-/// Check whether a process with the given name is running in /proc
-pub fn is_process_running(proc_name: &str) -> bool {
+/// Check whether a process whose name satisfies the predicate is running in /proc
+pub fn is_process_running_matching<F>(predicate: F) -> bool
+where
+    F: Fn(&str) -> bool,
+{
     let Ok(entries) = std::fs::read_dir("/proc") else {
         return false;
     };
@@ -1069,23 +1075,40 @@ pub fn is_process_running(proc_name: &str) -> bool {
         let file_str = file_name.to_string_lossy();
         if file_str.chars().all(|c| c.is_ascii_digit()) {
             let comm_path = entry.path().join("comm");
-            if let Ok(comm) = std::fs::read_to_string(&comm_path)
-                && comm.trim() == proc_name
-            {
-                return true;
+            if let Ok(comm) = std::fs::read_to_string(&comm_path) {
+                let name = comm.trim();
+                if predicate(name) {
+                    return true;
+                }
             }
         }
     }
     false
 }
 
+/// Check whether a process with the given name is running in /proc
+pub fn is_process_running(proc_name: &str) -> bool {
+    is_process_running_matching(|name| name == proc_name)
+}
+
 /// Determine whether the Zygisk provider's daemon is actually running
 pub fn is_zygisk_daemon_running(module_id: &str) -> bool {
     let id_lower = module_id.to_ascii_lowercase();
     match id_lower.as_str() {
-        "rezygisk" => is_process_running("rezygisk") || is_process_running("rezygiskd"),
-        "zygisksu" => is_process_running("zygiskd") || is_process_running("zygisk-companion"),
-        _ => false,
+        "rezygisk" => is_process_running_matching(|name| name.starts_with("rezygisk")),
+        "zygisksu" | "nyazygisk" | "neozygisk" => is_process_running_matching(|name| {
+            name.starts_with("zygiskd")
+                || name.starts_with("zygisk-ptrace")
+                || name.starts_with("zygisk-comp")
+                || name.starts_with("zygisk_comp")
+                || name.starts_with("nyazygisk")
+                || name.starts_with("neozygisk")
+        }),
+        _ => is_process_running_matching(|name| {
+            name.starts_with("zygiskd")
+                || name.starts_with("zygisk-ptrace")
+                || name.starts_with("rezygisk")
+        }),
     }
 }
 

--- a/userspace/ksud/src/module.rs
+++ b/userspace/ksud/src/module.rs
@@ -1036,23 +1036,6 @@ fn resolve_module_icon_path(
     }
 }
 
-/// Check if module has a zygisk shared library (client module) matching NeoZygisk load_modules behavior
-pub fn has_zygisk_library(path: &Path) -> bool {
-    let zygisk_dir = path.join(defs::MODULE_ZYGISK_DIR);
-    if zygisk_dir.is_dir() {
-        if let Ok(entries) = std::fs::read_dir(&zygisk_dir) {
-            for entry in entries.flatten() {
-                let p = entry.path();
-                if p.extension().is_some_and(|ext| ext == "so") {
-                    return true;
-                }
-            }
-        }
-        return true;
-    }
-    false
-}
-
 /// Determine whether the provided module is a Zygisk implementation / provider
 pub fn is_zygisk_provider(module_id: &str) -> bool {
     let id_lower = module_id.to_ascii_lowercase();
@@ -1166,7 +1149,6 @@ fn list_module(path: &str) -> Vec<HashMap<String, String>> {
         let is_provider = module_prop_map
             .get("id")
             .is_some_and(|id| is_zygisk_provider(id));
-        let zygisk_module = is_provider || has_zygisk_library(&path);
         let zygisk_running = if is_provider {
             module_prop_map
                 .get("id")
@@ -1181,7 +1163,7 @@ fn list_module(path: &str) -> Vec<HashMap<String, String>> {
         module_prop_map.insert("remove".to_owned(), remove.to_string());
         module_prop_map.insert("web".to_owned(), web.to_string());
         module_prop_map.insert("action".to_owned(), action.to_string());
-        module_prop_map.insert("zygisk".to_owned(), zygisk_module.to_string());
+        module_prop_map.insert("zygisk".to_owned(), is_provider.to_string());
         module_prop_map.insert("zygisk_provider".to_owned(), is_provider.to_string());
         module_prop_map.insert("zygisk_running".to_owned(), zygisk_running.to_string());
         module_prop_map.insert("mount".to_owned(), need_mount.to_string());


### PR DESCRIPTION
### Summary
1. **Restrict ZYGISK Tag**: Only Zygisk host implementations (providers) will receive the \ZYGISK\ badge tag in the module list, rather than tagging every client module containing \zygisk/*.so\.
2. **Broaden Zygisk Daemon Matching**:
   - Matches daemon variants such as \zygiskd64\, \zygiskd32\, \zygisk-ptrace64\, \zygisk-ptrace32\ (including 15-char \/proc/comm\ truncated names like \zygisk-ptrace6\).
   - Supports [NyaZygisk](https://github.com/HSSkyBoy/NyaZygisk) and NeoZygisk runtime process structures to accurately reflect running status instead of falling back to \Reboot required\.
   - Adds \
yazygisk\ and \
eozygisk\ module ID compatibility.